### PR TITLE
Improve COPR package handling and category filtering

### DIFF
--- a/discover/qml/ApplicationPage.qml
+++ b/discover/qml/ApplicationPage.qml
@@ -40,6 +40,16 @@ DiscoverPage {
     readonly property bool isTechnicalPackage: application.type == Discover.AbstractResource.ApplicationSupport
                                             || application.type == Discover.AbstractResource.System
 
+    function fetchBackendDetails() {
+        const fetchProjectPackages = appInfo.application["fetchProjectPackages"];
+        if (typeof fetchProjectPackages === "function") {
+            fetchProjectPackages.call(appInfo.application);
+        }
+    }
+
+    Component.onCompleted: fetchBackendDetails()
+    onApplicationChanged: fetchBackendDetails()
+
     function colorForLicenseType(licenseType: string): string {
         switch(licenseType) {
             case "free":

--- a/libdiscover/backends/PackageKitBackend/CoprClient.cpp
+++ b/libdiscover/backends/PackageKitBackend/CoprClient.cpp
@@ -1,6 +1,7 @@
 #include "CoprClient.h"
 #include "libdiscover_backend_packagekit_debug.h"
 
+#include <QDateTime>
 #include <QDebug>
 #include <QFile>
 #include <QJsonArray>
@@ -10,6 +11,7 @@
 #include <QSysInfo>
 #include <QTextStream>
 #include <QTimer>
+#include <QUrl>
 #include <QUrlQuery>
 
 CoprClient::CoprClient(QObject *parent)
@@ -190,7 +192,8 @@ void CoprClient::emitResultForRequest(const QString &requestType, const QJsonObj
     } else if (requestType.startsWith(QStringLiteral("getProjectPackages:"))) {
         QStringList parts = requestType.split(QLatin1Char(':'));
         if (parts.size() >= 3) {
-            Q_EMIT packagesFound(parsePackagesResponse(json, parts[1], parts[2]));
+            const QList<CoprPackageInfo> packages = parsePackagesResponse(json, parts[1], parts[2]);
+            Q_EMIT projectPackagesFound(parts[1], parts[2], packages);
         }
     }
 }
@@ -236,7 +239,10 @@ void CoprClient::processNextRequest()
                         || requestType == QStringLiteral("getLatestProjects")) {
                         Q_EMIT projectsFound(QList<CoprProjectInfo>());
                     } else if (requestType.startsWith(QStringLiteral("getProjectPackages:"))) {
-                        Q_EMIT packagesFound(QList<CoprPackageInfo>());
+                        const QStringList parts = requestType.split(QLatin1Char(':'));
+                        if (parts.size() >= 3) {
+                            Q_EMIT projectPackagesFound(parts[1], parts[2], QList<CoprPackageInfo>());
+                        }
                     }
                     curlProcess->deleteLater();
                     processNextRequest();
@@ -252,7 +258,10 @@ void CoprClient::processNextRequest()
                         || requestType == QStringLiteral("getLatestProjects")) {
                         Q_EMIT projectsFound(QList<CoprProjectInfo>());
                     } else if (requestType.startsWith(QStringLiteral("getProjectPackages:"))) {
-                        Q_EMIT packagesFound(QList<CoprPackageInfo>());
+                        const QStringList parts = requestType.split(QLatin1Char(':'));
+                        if (parts.size() >= 3) {
+                            Q_EMIT projectPackagesFound(parts[1], parts[2], QList<CoprPackageInfo>());
+                        }
                     }
                     curlProcess->deleteLater();
                     processNextRequest();
@@ -270,12 +279,14 @@ void CoprClient::processNextRequest()
                 processNextRequest();
             });
 
+    const QString timeoutSeconds = requestType == QStringLiteral("searchProjects") ? QStringLiteral("25") : QStringLiteral("10");
     curlProcess->start(QStringLiteral("curl"),
                        {QStringLiteral("-s"),
+                        QStringLiteral("--compressed"),
                         QStringLiteral("-H"),
                         QStringLiteral("Accept: application/json"),
                         QStringLiteral("--max-time"),
-                        QStringLiteral("15"),
+                        timeoutSeconds,
                         url.toString()});
 
     // Try to start more concurrent requests from the queue
@@ -317,6 +328,89 @@ QString CoprClient::convertMarkdownToHtml(const QString &markdown) const
     return html;
 }
 
+static QStringList jsonStringArray(const QJsonArray &array)
+{
+    QStringList values;
+    values.reserve(array.size());
+
+    for (const QJsonValue &value : array) {
+        const QString text = value.toString();
+        if (!text.isEmpty()) {
+            values.append(text);
+        }
+    }
+
+    return values;
+}
+
+static QString jsonValueToDisplayString(const QJsonValue &value)
+{
+    if (value.isString()) {
+        return value.toString();
+    }
+    if (value.isDouble()) {
+        return QString::number(value.toInt());
+    }
+    if (value.isBool()) {
+        return value.toBool() ? QStringLiteral("true") : QStringLiteral("false");
+    }
+    return {};
+}
+
+static QDateTime unixTimestampToDateTime(const QJsonValue &value)
+{
+    const qint64 timestamp = value.toVariant().toLongLong();
+    if (timestamp <= 0) {
+        return {};
+    }
+    return QDateTime::fromSecsSinceEpoch(timestamp);
+}
+
+static QString sourceUrlFromSourceDict(const QJsonObject &source)
+{
+    const QString url = source.value(QStringLiteral("url")).toString();
+    if (!url.isEmpty()) {
+        return url;
+    }
+
+    const QString cloneUrl = source.value(QStringLiteral("clone_url")).toString();
+    if (!cloneUrl.isEmpty()) {
+        return cloneUrl;
+    }
+
+    return {};
+}
+
+CoprProjectInfo CoprClient::parseProjectObject(const QJsonObject &obj)
+{
+    CoprProjectInfo project;
+    project.owner = obj.value(QStringLiteral("ownername")).toString();
+    project.name = obj.value(QStringLiteral("name")).toString();
+    project.fullName = obj.value(QStringLiteral("full_name")).toString();
+    project.description = convertMarkdownToHtml(obj.value(QStringLiteral("description")).toString());
+    project.instructions = convertMarkdownToHtml(obj.value(QStringLiteral("instructions")).toString());
+    project.contact = obj.value(QStringLiteral("contact")).toString();
+    project.id = obj.value(QStringLiteral("id")).toInt();
+    project.homepage = obj.value(QStringLiteral("homepage")).toString();
+    project.additionalRepos = jsonStringArray(obj.value(QStringLiteral("additional_repos")).toArray());
+    project.repoPriority = jsonValueToDisplayString(obj.value(QStringLiteral("repo_priority")));
+    project.appstream = obj.value(QStringLiteral("appstream")).toBool();
+    project.develMode = obj.value(QStringLiteral("devel_mode")).toBool();
+    project.enableNet = obj.value(QStringLiteral("enable_net")).toBool();
+    project.followFedoraBranching = obj.value(QStringLiteral("follow_fedora_branching")).toBool();
+    project.autoPrune = obj.value(QStringLiteral("auto_prune")).toBool();
+    project.moduleHotfixes = obj.value(QStringLiteral("module_hotfixes")).toBool();
+
+    const QJsonObject chrootRepos = obj.value(QStringLiteral("chroot_repos")).toObject();
+    if (!chrootRepos.isEmpty()) {
+        project.chroots = chrootRepos.keys();
+    } else {
+        project.chroots = jsonStringArray(obj.value(QStringLiteral("chroots")).toArray());
+    }
+
+    return project;
+}
+
 QList<CoprProjectInfo> CoprClient::parseProjectsResponse(const QJsonObject &json)
 {
     QList<CoprProjectInfo> projects;
@@ -324,31 +418,7 @@ QList<CoprProjectInfo> CoprClient::parseProjectsResponse(const QJsonObject &json
     QJsonArray items = json.value(QStringLiteral("items")).toArray();
 
     for (const QJsonValue &value : items) {
-        QJsonObject obj = value.toObject();
-
-        CoprProjectInfo project;
-        project.owner = obj.value(QStringLiteral("ownername")).toString();
-        project.name = obj.value(QStringLiteral("name")).toString();
-        project.description = convertMarkdownToHtml(obj.value(QStringLiteral("description")).toString());
-        project.id = obj.value(QStringLiteral("id")).toInt();
-        project.homepage = obj.value(QStringLiteral("homepage")).toString();
-
-        // Try to get chroots from different possible fields
-        QJsonObject chrootRepos = obj.value(QStringLiteral("chroot_repos")).toObject();
-        if (!chrootRepos.isEmpty()) {
-            project.chroots = chrootRepos.keys();
-        } else {
-            // For search results, chroots might be in a different field
-            QJsonArray chrootsArray = obj.value(QStringLiteral("chroots")).toArray();
-            for (const QJsonValue &chrootVal : chrootsArray) {
-                QString chrootName = chrootVal.toString();
-                if (!chrootName.isEmpty()) {
-                    project.chroots.append(chrootName);
-                }
-            }
-        }
-
-        projects.append(project);
+        projects.append(parseProjectObject(value.toObject()));
     }
 
     return projects;
@@ -359,14 +429,11 @@ CoprProjectInfo CoprClient::parseProjectResponse(const QJsonObject &json)
     CoprProjectInfo project;
 
     QJsonObject obj = json.value(QStringLiteral("project")).toObject();
+    if (obj.isEmpty()) {
+        obj = json;
+    }
 
-    project.owner = obj.value(QStringLiteral("ownername")).toString();
-    project.name = obj.value(QStringLiteral("name")).toString();
-    project.description = convertMarkdownToHtml(obj.value(QStringLiteral("description")).toString());
-    project.id = obj.value(QStringLiteral("id")).toInt();
-    project.homepage = obj.value(QStringLiteral("homepage")).toString();
-
-    project.chroots = obj.value(QStringLiteral("chroot_repos")).toObject().keys();
+    project = parseProjectObject(obj);
 
     return project;
 }
@@ -384,31 +451,40 @@ QList<CoprPackageInfo> CoprClient::parsePackagesResponse(const QJsonObject &json
         package.name = obj.value(QStringLiteral("name")).toString();
         package.owner = owner;
         package.projectName = project;
+        package.sourceType = obj.value(QStringLiteral("source_type")).toString();
 
         // Extract info from latest build if available
         QJsonObject builds = obj.value(QStringLiteral("builds")).toObject();
-        QJsonObject latestBuild = builds.value(QStringLiteral("latest")).toObject();
+        QJsonObject latestBuild = builds.value(QStringLiteral("latest_succeeded")).toObject();
+        if (latestBuild.isEmpty()) {
+            latestBuild = builds.value(QStringLiteral("latest")).toObject();
+        }
 
         if (!latestBuild.isEmpty()) {
             // Get build chroots to determine availability
-            QJsonArray chroots = latestBuild.value(QStringLiteral("chroots")).toArray();
-            for (const QJsonValue &chrootVal : chroots) {
-                QString chrootName = chrootVal.toString();
-                if (!chrootName.isEmpty()) {
-                    package.availableChroots.append(chrootName);
-                }
-            }
+            package.availableChroots = jsonStringArray(latestBuild.value(QStringLiteral("chroots")).toArray());
 
             // Check if available for current Fedora
             package.isAvailableForCurrentFedora = package.availableChroots.contains(m_currentChroot);
+            package.latestBuildState = latestBuild.value(QStringLiteral("state")).toString();
+            package.latestBuildRepoUrl = latestBuild.value(QStringLiteral("repo_url")).toString();
+            package.latestBuildSubmitter = latestBuild.value(QStringLiteral("submitter")).toString();
+            package.latestBuildSubmittedOn = unixTimestampToDateTime(latestBuild.value(QStringLiteral("submitted_on")));
+            package.latestBuildStartedOn = unixTimestampToDateTime(latestBuild.value(QStringLiteral("started_on")));
+            package.latestBuildEndedOn = unixTimestampToDateTime(latestBuild.value(QStringLiteral("ended_on")));
+
+            const QJsonObject sourcePackage = latestBuild.value(QStringLiteral("source_package")).toObject();
+            package.version = sourcePackage.value(QStringLiteral("version")).toString();
         }
 
         // Get source info if available
         QJsonObject source = obj.value(QStringLiteral("source_dict")).toObject();
         if (!source.isEmpty()) {
-            QString url = source.value(QStringLiteral("url")).toString();
-            if (!url.isEmpty()) {
-                package.homepage = url;
+            package.sourceUrl = sourceUrlFromSourceDict(source);
+            package.sourceSpec = source.value(QStringLiteral("spec")).toString();
+            package.sourceSubdirectory = source.value(QStringLiteral("subdirectory")).toString();
+            if (package.homepage.isEmpty()) {
+                package.homepage = package.sourceUrl;
             }
         }
 

--- a/libdiscover/backends/PackageKitBackend/CoprClient.h
+++ b/libdiscover/backends/PackageKitBackend/CoprClient.h
@@ -20,20 +20,53 @@ struct CoprPackageInfo {
     QString description;
     QString owner;
     QString projectName;
+    QString projectFullName;
     QString version;
     QStringList availableChroots;
-    bool isAvailableForCurrentFedora;
-    int projectId;
+    bool isAvailableForCurrentFedora = false;
+    int projectId = 0;
     QString homepage;
+    QString instructions;
+    QString contact;
+    QStringList additionalRepos;
+    QString repoPriority;
+    bool appstream = false;
+    bool develMode = false;
+    bool enableNet = false;
+    bool followFedoraBranching = false;
+    bool autoPrune = false;
+    bool moduleHotfixes = false;
+    bool isProjectResource = false;
+    QString sourceType;
+    QString sourceUrl;
+    QString sourceSpec;
+    QString sourceSubdirectory;
+    QString latestBuildState;
+    QString latestBuildRepoUrl;
+    QString latestBuildSubmitter;
+    QDateTime latestBuildSubmittedOn;
+    QDateTime latestBuildStartedOn;
+    QDateTime latestBuildEndedOn;
 };
 
 struct CoprProjectInfo {
     QString owner;
     QString name;
+    QString fullName;
     QString description;
     QStringList chroots;
     QString homepage;
-    int id;
+    int id = 0;
+    QString instructions;
+    QString contact;
+    QStringList additionalRepos;
+    QString repoPriority;
+    bool appstream = false;
+    bool develMode = false;
+    bool enableNet = false;
+    bool followFedoraBranching = false;
+    bool autoPrune = false;
+    bool moduleHotfixes = false;
 };
 
 class CoprClient : public QObject
@@ -60,10 +93,12 @@ Q_SIGNALS:
     void projectsFound(const QList<CoprProjectInfo> &projects);
     void projectInfoReceived(const CoprProjectInfo &project);
     void packagesFound(const QList<CoprPackageInfo> &packages);
+    void projectPackagesFound(const QString &owner, const QString &project, const QList<CoprPackageInfo> &packages);
     void errorOccurred(const QString &errorMessage);
 
 private:
     QList<CoprProjectInfo> parseProjectsResponse(const QJsonObject &json);
+    CoprProjectInfo parseProjectObject(const QJsonObject &json);
     CoprProjectInfo parseProjectResponse(const QJsonObject &json);
     QList<CoprPackageInfo> parsePackagesResponse(const QJsonObject &json, const QString &owner, const QString &project);
     QString convertMarkdownToHtml(const QString &markdown) const;

--- a/libdiscover/backends/PackageKitBackend/CoprResource.cpp
+++ b/libdiscover/backends/PackageKitBackend/CoprResource.cpp
@@ -1,23 +1,163 @@
 #include "CoprResource.h"
 #include "PackageKitBackend.h"
 
+#include <KIO/ApplicationLauncherJob>
 #include <KLocalizedString>
 #include <KService>
-#include <KIO/ApplicationLauncherJob>
 #include <QDebug>
-#include <QProcess>
 #include <QDir>
 #include <QDirIterator>
 #include <QFileInfo>
+#include <QLocale>
+
+#include <algorithm>
+
+static QString htmlParagraphBreak()
+{
+    return QStringLiteral("<br><br>");
+}
+
+static QString htmlLabel(const QString &label)
+{
+    return QStringLiteral("<b>%1</b>").arg(label.toHtmlEscaped());
+}
+
+static void appendTextDetail(QString &html, const QString &label, const QString &value)
+{
+    if (value.isEmpty()) {
+        return;
+    }
+
+    html += QStringLiteral("<br>");
+    html += htmlLabel(label) + QStringLiteral(" ") + value.toHtmlEscaped();
+}
+
+static void appendLinkDetail(QString &html, const QString &label, const QString &url, const QString &text = {})
+{
+    if (url.isEmpty()) {
+        return;
+    }
+
+    const QString linkText = text.isEmpty() ? url : text;
+    html += QStringLiteral("<br>");
+    html += htmlLabel(label) + QStringLiteral(" ");
+    html += QStringLiteral("<a href=\"%1\">%2</a>").arg(url.toHtmlEscaped(), linkText.toHtmlEscaped());
+}
+
+static QString formatBuildDateTime(const QDateTime &dateTime)
+{
+    if (!dateTime.isValid()) {
+        return {};
+    }
+
+    return QLocale().toString(dateTime.toLocalTime(), QLocale::ShortFormat);
+}
+
+static QString formattedChrootsSummary(const QStringList &chroots)
+{
+    QStringList fedoraVersions;
+    QStringList architectures;
+
+    for (const QString &chroot : chroots) {
+        if (!chroot.startsWith(QStringLiteral("fedora-"))) {
+            continue;
+        }
+
+        const QStringList parts = chroot.split(QLatin1Char('-'));
+        if (parts.size() < 3) {
+            continue;
+        }
+
+        const QString version = parts[1];
+        const QString arch = parts[2];
+
+        if (!fedoraVersions.contains(version)) {
+            fedoraVersions.append(version);
+        }
+        if (!architectures.contains(arch)) {
+            architectures.append(arch);
+        }
+    }
+
+    if (fedoraVersions.isEmpty()) {
+        return chroots.join(QStringLiteral(", "));
+    }
+
+    if (architectures.isEmpty()) {
+        return QStringLiteral("Fedora %1").arg(fedoraVersions.join(QStringLiteral(", ")));
+    }
+
+    return QStringLiteral("Fedora %1 (%2)").arg(fedoraVersions.join(QStringLiteral(", ")), architectures.join(QStringLiteral(", ")));
+}
+
+static QString boolText(bool value)
+{
+    return value ? i18nc("@item", "yes") : i18nc("@item", "no");
+}
+
+static QStringList mergedChroots(const QStringList &baseChroots, const QList<CoprPackageInfo> &packages)
+{
+    QStringList chroots = baseChroots;
+    for (const CoprPackageInfo &package : packages) {
+        for (const QString &chroot : package.availableChroots) {
+            if (!chroots.contains(chroot)) {
+                chroots.append(chroot);
+            }
+        }
+    }
+    return chroots;
+}
+
+static QString packageSummaryLine(const CoprPackageInfo &package)
+{
+    QString summary = package.name.toHtmlEscaped();
+    if (!package.version.isEmpty()) {
+        summary += QStringLiteral(" ") + QStringLiteral("(%1)").arg(package.version.toHtmlEscaped());
+    }
+    if (!package.latestBuildState.isEmpty()) {
+        summary += QStringLiteral(" - ") + i18n("latest build: %1", package.latestBuildState.toHtmlEscaped());
+    }
+
+    const QString chroots = formattedChrootsSummary(package.availableChroots);
+    if (!chroots.isEmpty()) {
+        summary += QStringLiteral(" - ") + chroots.toHtmlEscaped();
+    }
+
+    return summary;
+}
 
 CoprResource::CoprResource(const CoprPackageInfo &packageInfo, AbstractResourcesBackend *parent)
-    : PackageKitResource(packageInfo.name, QString(), qobject_cast<PackageKitBackend*>(parent))
+    : PackageKitResource(packageInfo.name, QString(), qobject_cast<PackageKitBackend *>(parent))
     , m_owner(packageInfo.owner)
     , m_project(packageInfo.projectName)
+    , m_installPackageName(packageInfo.isProjectResource ? QString() : packageInfo.name)
+    , m_projectFullName(packageInfo.projectFullName)
     , m_description(packageInfo.description)
+    , m_version(packageInfo.version)
     , m_availableChroots(packageInfo.availableChroots)
     , m_isAvailableForCurrentFedora(packageInfo.isAvailableForCurrentFedora)
     , m_homepage(packageInfo.homepage)
+    , m_instructions(packageInfo.instructions)
+    , m_contact(packageInfo.contact)
+    , m_additionalRepos(packageInfo.additionalRepos)
+    , m_repoPriority(packageInfo.repoPriority)
+    , m_appstream(packageInfo.appstream)
+    , m_develMode(packageInfo.develMode)
+    , m_enableNet(packageInfo.enableNet)
+    , m_followFedoraBranching(packageInfo.followFedoraBranching)
+    , m_autoPrune(packageInfo.autoPrune)
+    , m_moduleHotfixes(packageInfo.moduleHotfixes)
+    , m_isProjectResource(packageInfo.isProjectResource)
+    , m_sourceType(packageInfo.sourceType)
+    , m_sourceUrl(packageInfo.sourceUrl)
+    , m_sourceSpec(packageInfo.sourceSpec)
+    , m_sourceSubdirectory(packageInfo.sourceSubdirectory)
+    , m_latestBuildState(packageInfo.latestBuildState)
+    , m_latestBuildRepoUrl(packageInfo.latestBuildRepoUrl)
+    , m_latestBuildSubmitter(packageInfo.latestBuildSubmitter)
+    , m_latestBuildSubmittedOn(packageInfo.latestBuildSubmittedOn)
+    , m_latestBuildStartedOn(packageInfo.latestBuildStartedOn)
+    , m_latestBuildEndedOn(packageInfo.latestBuildEndedOn)
 {
     // Check if the package is already installed (deferred to avoid blocking the UI during batch creation)
     QMetaObject::invokeMethod(this, &CoprResource::checkInstalledState, Qt::QueuedConnection);
@@ -37,76 +177,169 @@ QString CoprResource::origin() const
     return QStringLiteral("COPR");
 }
 
+QString CoprResource::packageName() const
+{
+    return m_installPackageName;
+}
+
+QStringList CoprResource::allPackageNames() const
+{
+    return m_installPackageName.isEmpty() ? QStringList() : QStringList{m_installPackageName};
+}
+
 QString CoprResource::comment()
 {
     // Return a short one-line description for the package list view
     // Don't return the full HTML description here
-    return i18n("COPR package from %1/%2", m_owner, m_project);
+    return i18n("COPR package from %1", m_projectFullName.isEmpty() ? QStringLiteral("%1/%2").arg(m_owner, m_project) : m_projectFullName);
 }
 
 QString CoprResource::longDescription()
 {
-    // If we have a description from COPR (already converted from Markdown to HTML),
-    // just return it as is - it already contains all the information
+    QString desc;
+
     if (!m_description.isEmpty()) {
-        QString desc = m_description;
-
-        // Only add our additional metadata at the end
-        desc += QStringLiteral("<br><br><hr><br>");
-        desc += QStringLiteral("<b>") + i18n("COPR Repository:") + QStringLiteral("</b> ");
-        desc += m_owner + QStringLiteral("/") + m_project;
-
-        // Parse available versions
-        QStringList fedoraVersions;
-        QStringList architectures;
-
-        for (const QString &chroot : m_availableChroots) {
-            if (chroot.startsWith(QStringLiteral("fedora-"))) {
-                QStringList parts = chroot.split(QLatin1Char('-'));
-                if (parts.size() >= 3) {
-                    QString version = parts[1];
-                    QString arch = parts[2];
-
-                    if (!fedoraVersions.contains(version)) {
-                        fedoraVersions.append(version);
-                    }
-                    if (!architectures.contains(arch)) {
-                        architectures.append(arch);
-                    }
-                }
-            }
-        }
-
-        if (!fedoraVersions.isEmpty()) {
-            desc += QStringLiteral("<br><br>");
-            desc += QStringLiteral("<b>") + i18n("Available for:") + QStringLiteral("</b> Fedora ");
-            desc += fedoraVersions.join(QStringLiteral(", "));
-            desc += QStringLiteral(" (");
-            desc += architectures.join(QStringLiteral(", "));
-            desc += QStringLiteral(")");
-        }
-
-        desc += QStringLiteral("<br><br>");
-        if (m_isAvailableForCurrentFedora) {
-            desc += QStringLiteral("<span style='color: green; font-weight: bold;'>✓ ") + i18n("Available for your Fedora version") + QStringLiteral("</span>");
-        } else {
-            desc += QStringLiteral("<span style='color: red; font-weight: bold;'>⚠ ") + i18n("Not available for your Fedora version") + QStringLiteral("</span>");
-        }
-
-        desc += QStringLiteral("<br><br>");
-        desc += QStringLiteral("<span style='color: #ff8800;'><b>") + i18n("Notice:") + QStringLiteral("</b> ");
-        desc += i18n("COPR repositories are not officially supported by Fedora. Use at your own risk.") + QStringLiteral("</span>");
-
-        return desc;
+        desc = m_description;
     } else {
-        // No description from COPR, create a default one
-        return i18n("Package from COPR repository %1/%2", m_owner, m_project);
+        desc = i18n("Package from COPR repository %1/%2", m_owner, m_project);
+    }
+
+    desc += htmlParagraphBreak();
+    desc += QStringLiteral("<hr>");
+    desc += htmlParagraphBreak();
+    desc += htmlLabel(i18n("COPR Details"));
+
+    appendTextDetail(desc, i18n("Repository:"), m_projectFullName.isEmpty() ? QStringLiteral("%1/%2").arg(m_owner, m_project) : m_projectFullName);
+    if (!m_isProjectResource) {
+        appendTextDetail(desc, i18n("Package:"), packageName());
+    } else if (m_projectPackages.isEmpty()) {
+        appendTextDetail(desc, i18n("Install target:"), i18n("Unknown until package metadata is loaded"));
+        if (m_projectPackagesRequested) {
+            appendTextDetail(desc, i18n("Project packages:"), i18n("Loading or unavailable"));
+        }
+    } else {
+        if (m_installPackageName.isEmpty()) {
+            appendTextDetail(desc, i18n("Install target:"), i18n("Select a specific package result to install"));
+        } else {
+            appendTextDetail(desc, i18n("Install target:"), m_installPackageName);
+        }
+        desc += QStringLiteral("<br>");
+        desc += htmlLabel(i18n("Packages in this project:"));
+        desc += QStringLiteral("<ul>");
+        for (const CoprPackageInfo &package : m_projectPackages) {
+            desc += QStringLiteral("<li>") + packageSummaryLine(package) + QStringLiteral("</li>");
+        }
+        desc += QStringLiteral("</ul>");
+    }
+    appendTextDetail(desc, i18n("Latest version:"), m_version);
+    appendTextDetail(desc, i18n("Latest build:"), m_latestBuildState);
+    appendTextDetail(desc, i18n("Submitted:"), formatBuildDateTime(m_latestBuildSubmittedOn));
+    appendTextDetail(desc, i18n("Started:"), formatBuildDateTime(m_latestBuildStartedOn));
+    appendTextDetail(desc, i18n("Finished:"), formatBuildDateTime(m_latestBuildEndedOn));
+    appendTextDetail(desc, i18n("Submitter:"), m_latestBuildSubmitter);
+    appendLinkDetail(desc, i18n("Build repository:"), m_latestBuildRepoUrl);
+
+    const QStringList allChroots = mergedChroots(m_availableChroots, m_projectPackages);
+    const QString chrootsSummary = formattedChrootsSummary(allChroots);
+    appendTextDetail(desc, i18n("Available for:"), chrootsSummary);
+
+    desc += htmlParagraphBreak();
+    if (allChroots.isEmpty()) {
+        desc += QStringLiteral("<span style='font-weight: bold;'>");
+        desc += i18n("Availability for your Fedora version is unknown.");
+        desc += QStringLiteral("</span>");
+    } else if (m_isAvailableForCurrentFedora) {
+        desc += QStringLiteral("<span style='color: green; font-weight: bold;'>");
+        desc += i18n("Available for your Fedora version.");
+        desc += QStringLiteral("</span>");
+    } else {
+        desc += QStringLiteral("<span style='color: red; font-weight: bold;'>");
+        desc += i18n("Not available for your Fedora version.");
+        desc += QStringLiteral("</span>");
+    }
+
+    if (!m_sourceType.isEmpty() || !m_sourceUrl.isEmpty() || !m_sourceSpec.isEmpty() || !m_sourceSubdirectory.isEmpty()) {
+        desc += htmlParagraphBreak();
+        desc += htmlLabel(i18n("Source"));
+        appendTextDetail(desc, i18n("Type:"), m_sourceType);
+        appendLinkDetail(desc, i18n("URL:"), m_sourceUrl);
+        appendTextDetail(desc, i18n("Spec:"), m_sourceSpec);
+        appendTextDetail(desc, i18n("Subdirectory:"), m_sourceSubdirectory);
+    }
+
+    if (!m_contact.isEmpty() || !m_instructions.isEmpty()) {
+        desc += htmlParagraphBreak();
+        desc += htmlLabel(i18n("Project Information"));
+        appendTextDetail(desc, i18n("Contact:"), m_contact);
+        if (!m_instructions.isEmpty()) {
+            desc += htmlParagraphBreak();
+            desc += htmlLabel(i18n("Instructions"));
+            desc += QStringLiteral("<br>");
+            desc += m_instructions;
+        }
+    }
+
+    desc += htmlParagraphBreak();
+    desc += QStringLiteral("<span style='color: #ff8800;'><b>");
+    desc += i18n("Notice:");
+    desc += QStringLiteral("</b> ");
+    desc += i18n("COPR repositories are not officially supported by Fedora. Use at your own risk.");
+    desc += QStringLiteral("</span>");
+
+    QStringList warnings;
+    if (m_develMode) {
+        warnings.append(i18n("This COPR project is in development mode."));
+    }
+    if (!m_additionalRepos.isEmpty()) {
+        warnings.append(i18n("This project uses additional repositories: %1", m_additionalRepos.join(QStringLiteral(", "))));
+    }
+    if (m_enableNet) {
+        warnings.append(i18n("Network access is enabled during builds."));
+    }
+    if (!m_repoPriority.isEmpty()) {
+        warnings.append(i18n("Repository priority: %1", m_repoPriority));
+    }
+    if (m_moduleHotfixes) {
+        warnings.append(i18n("Module hotfixes are enabled for this repository."));
+    }
+
+    if (!warnings.isEmpty()) {
+        desc += htmlParagraphBreak();
+        desc += QStringLiteral("<span style='color: #ff8800;'>");
+        desc += htmlLabel(i18n("Additional warnings:"));
+        desc += QStringLiteral("<ul>");
+        for (const QString &warning : warnings) {
+            desc += QStringLiteral("<li>") + warning.toHtmlEscaped() + QStringLiteral("</li>");
+        }
+        desc += QStringLiteral("</ul></span>");
+    }
+
+    desc += htmlParagraphBreak();
+    desc += htmlLabel(i18n("Repository flags"));
+    appendTextDetail(desc, i18n("AppStream metadata:"), boolText(m_appstream));
+    appendTextDetail(desc, i18n("Follows Fedora branching:"), boolText(m_followFedoraBranching));
+    appendTextDetail(desc, i18n("Auto-prune:"), boolText(m_autoPrune));
+
+    return desc;
+}
+
+void CoprResource::fetchProjectPackages()
+{
+    if (!m_isProjectResource || m_projectPackagesRequested) {
+        return;
+    }
+
+    m_projectPackagesRequested = true;
+    if (auto pkBackend = qobject_cast<PackageKitBackend *>(backend())) {
+        if (auto client = pkBackend->coprClient()) {
+            client->getProjectPackages(m_owner, m_project);
+        }
     }
 }
 
 QString CoprResource::availableVersion() const
 {
-    return i18n("COPR latest");
+    return m_version;
 }
 
 QString CoprResource::installedVersion() const
@@ -125,14 +358,11 @@ QUrl CoprResource::homepage()
 
 AbstractResource::State CoprResource::state()
 {
-    // Check if the package is actually installed
-    // We need to query the system to see if the package exists
-
-    // For now, let's check using a simple approach
-    // Later we can integrate with PackageKit to get the actual state
-
     if (m_isInstalled) {
         return AbstractResource::Installed;
+    }
+    if (m_installPackageName.isEmpty() && m_isProjectResource && !m_projectPackagesLoaded) {
+        return AbstractResource::Broken;
     }
 
     return AbstractResource::None;
@@ -140,12 +370,109 @@ AbstractResource::State CoprResource::state()
 
 void CoprResource::setState(AbstractResource::State state)
 {
-    m_isInstalled = (state == AbstractResource::Installed);
-    Q_EMIT stateChanged();
+    setInstalledStateFromSystem(state == AbstractResource::Installed);
+}
+
+void CoprResource::setInstalledStateFromSystem(bool installed)
+{
+    const bool wasInstalled = m_isInstalled;
+    m_isInstalled = installed;
 
     // Also emit the change through the backend so the UI updates
-    if (backend()) {
+    if (wasInstalled != m_isInstalled) {
+        Q_EMIT stateChanged();
+    }
+    if (backend() && wasInstalled != m_isInstalled) {
         Q_EMIT backend()->resourcesChanged(this, {"state"});
+    }
+}
+
+void CoprResource::setProjectPackages(const QList<CoprPackageInfo> &packages)
+{
+    const AbstractResource::State previousState = state();
+    const QString previousInstallPackageName = m_installPackageName;
+
+    m_projectPackages = packages;
+    m_projectPackagesLoaded = true;
+
+    if (m_isProjectResource) {
+        if (const CoprPackageInfo *package = preferredProjectPackage()) {
+            m_installPackageName = package->name;
+            applyPackageDetails(*package);
+        } else {
+            m_installPackageName.clear();
+        }
+    }
+
+    m_availableChroots = mergedChroots(m_availableChroots, m_projectPackages);
+    m_isAvailableForCurrentFedora = std::any_of(m_availableChroots.cbegin(), m_availableChroots.cend(), [this](const QString &chroot) {
+        if (auto pkBackend = qobject_cast<PackageKitBackend *>(backend())) {
+            if (auto client = pkBackend->coprClient()) {
+                return chroot == client->getCurrentChroot();
+            }
+        }
+        return false;
+    });
+
+    Q_EMIT longDescriptionChanged();
+    Q_EMIT versionsChanged();
+    if (previousState != state() || previousInstallPackageName != m_installPackageName) {
+        Q_EMIT stateChanged();
+    }
+    if (previousInstallPackageName != m_installPackageName && !m_installPackageName.isEmpty()) {
+        QMetaObject::invokeMethod(this, &CoprResource::checkInstalledState, Qt::QueuedConnection);
+    }
+}
+
+const CoprPackageInfo *CoprResource::preferredProjectPackage() const
+{
+    if (m_projectPackages.isEmpty()) {
+        return nullptr;
+    }
+    if (m_projectPackages.size() == 1) {
+        return &m_projectPackages.constFirst();
+    }
+
+    const auto it = std::find_if(m_projectPackages.cbegin(), m_projectPackages.cend(), [this](const CoprPackageInfo &package) {
+        return package.name.compare(m_project, Qt::CaseInsensitive) == 0;
+    });
+    return it == m_projectPackages.cend() ? nullptr : &(*it);
+}
+
+void CoprResource::applyPackageDetails(const CoprPackageInfo &package)
+{
+    if (m_version.isEmpty()) {
+        m_version = package.version;
+    }
+    if (m_latestBuildState.isEmpty()) {
+        m_latestBuildState = package.latestBuildState;
+    }
+    if (m_latestBuildRepoUrl.isEmpty()) {
+        m_latestBuildRepoUrl = package.latestBuildRepoUrl;
+    }
+    if (m_latestBuildSubmitter.isEmpty()) {
+        m_latestBuildSubmitter = package.latestBuildSubmitter;
+    }
+    if (!m_latestBuildSubmittedOn.isValid()) {
+        m_latestBuildSubmittedOn = package.latestBuildSubmittedOn;
+    }
+    if (!m_latestBuildStartedOn.isValid()) {
+        m_latestBuildStartedOn = package.latestBuildStartedOn;
+    }
+    if (!m_latestBuildEndedOn.isValid()) {
+        m_latestBuildEndedOn = package.latestBuildEndedOn;
+    }
+    if (m_sourceType.isEmpty()) {
+        m_sourceType = package.sourceType;
+    }
+    if (m_sourceUrl.isEmpty()) {
+        m_sourceUrl = package.sourceUrl;
+    }
+    if (m_sourceSpec.isEmpty()) {
+        m_sourceSpec = package.sourceSpec;
+    }
+    if (m_sourceSubdirectory.isEmpty()) {
+        m_sourceSubdirectory = package.sourceSubdirectory;
     }
 }
 
@@ -156,7 +483,7 @@ QVariant CoprResource::icon() const
 
 QString CoprResource::sizeDescription()
 {
-    return i18n("Unknown size");
+    return {};
 }
 
 QString CoprResource::author() const
@@ -170,46 +497,28 @@ QString CoprResource::sourceIcon() const
     return QStringLiteral("cloud-upload");
 }
 
+QDate CoprResource::releaseDate() const
+{
+    if (m_latestBuildEndedOn.isValid()) {
+        return m_latestBuildEndedOn.date();
+    }
+    if (m_latestBuildSubmittedOn.isValid()) {
+        return m_latestBuildSubmittedOn.date();
+    }
+    return {};
+}
+
 void CoprResource::checkInstalledState()
 {
-    // Store previous state to check if it actually changed
-    bool wasInstalled = m_isInstalled;
-
-    // Check if the package is installed using rpm command
-    QProcess process;
-    process.start(QStringLiteral("rpm"), {QStringLiteral("-q"), packageName()});
-    process.waitForFinished();
-
-    if (process.exitCode() != 0) {
-        // Package is not installed at all
-        m_isInstalled = false;
-    } else {
-        // Package is installed, now check if it's from this specific COPR repo
-        // Get the vendor/packager info to determine the source
-        QProcess vendorProcess;
-        vendorProcess.start(QStringLiteral("rpm"), {QStringLiteral("-qi"), packageName()});
-        vendorProcess.waitForFinished();
-
-        QString output = QString::fromUtf8(vendorProcess.readAllStandardOutput());
-
-        // Check if the package is from the specific COPR repository
-        // COPR packages have "Vendor: Fedora Copr - user <owner>" format
-        QString vendorString = QStringLiteral("Fedora Copr - user ") + m_owner;
-        QString vendorString2 = QStringLiteral("Fedora Copr - group ") + m_owner;  // For group-owned repos
-
-        // Also check in the source RPM name which often includes repo info
-        QString sourcePattern = m_owner + QStringLiteral("-") + packageName();
-        QString sourcePattern2 = QStringLiteral("copr:") + m_owner;
-
-        m_isInstalled = output.contains(vendorString, Qt::CaseInsensitive) ||
-                       output.contains(vendorString2, Qt::CaseInsensitive) ||
-                       output.contains(sourcePattern, Qt::CaseInsensitive) ||
-                       output.contains(sourcePattern2, Qt::CaseInsensitive);
+    if (m_installPackageName.isEmpty()) {
+        setInstalledStateFromSystem(false);
+        return;
     }
 
-    // Only emit signal if state actually changed
-    if (wasInstalled != m_isInstalled) {
-        Q_EMIT stateChanged();
+    if (auto pkBackend = qobject_cast<PackageKitBackend *>(backend())) {
+        pkBackend->requestCoprInstalledStateCheck(this);
+    } else {
+        setInstalledStateFromSystem(false);
     }
 }
 

--- a/libdiscover/backends/PackageKitBackend/CoprResource.h
+++ b/libdiscover/backends/PackageKitBackend/CoprResource.h
@@ -16,6 +16,8 @@ public:
 
     QString section() override;
     QString origin() const override;
+    QString packageName() const override;
+    QStringList allPackageNames() const override;
     QString comment() override;
     QString longDescription() override;
     QString availableVersion() const override;
@@ -23,6 +25,7 @@ public:
     QUrl homepage() override;
     QString author() const override;
     QString sourceIcon() const override;
+    QDate releaseDate() const override;
 
     AbstractResource::State state() override;
     QVariant icon() const override;
@@ -35,6 +38,9 @@ public:
 
     void setAvailableForCurrentFedora(bool available) { m_isAvailableForCurrentFedora = available; }
     void setState(AbstractResource::State state);
+    void setInstalledStateFromSystem(bool installed);
+    void setProjectPackages(const QList<CoprPackageInfo> &packages);
+    Q_INVOKABLE void fetchProjectPackages();
     void checkInstalledState();
 
     bool canExecute() const override;
@@ -42,13 +48,42 @@ public:
 
 private:
     QString findDesktopFile() const;
+    const CoprPackageInfo *preferredProjectPackage() const;
+    void applyPackageDetails(const CoprPackageInfo &package);
 
     QString m_owner;
     QString m_project;
+    QString m_installPackageName;
+    QString m_projectFullName;
     QString m_description;
+    QString m_version;
     QStringList m_availableChroots;
     bool m_isAvailableForCurrentFedora;
     QString m_homepage;
+    QString m_instructions;
+    QString m_contact;
+    QStringList m_additionalRepos;
+    QString m_repoPriority;
+    bool m_appstream = false;
+    bool m_develMode = false;
+    bool m_enableNet = false;
+    bool m_followFedoraBranching = false;
+    bool m_autoPrune = false;
+    bool m_moduleHotfixes = false;
+    bool m_isProjectResource = false;
+    QString m_sourceType;
+    QString m_sourceUrl;
+    QString m_sourceSpec;
+    QString m_sourceSubdirectory;
+    QString m_latestBuildState;
+    QString m_latestBuildRepoUrl;
+    QString m_latestBuildSubmitter;
+    QDateTime m_latestBuildSubmittedOn;
+    QDateTime m_latestBuildStartedOn;
+    QDateTime m_latestBuildEndedOn;
+    QList<CoprPackageInfo> m_projectPackages;
+    bool m_projectPackagesRequested = false;
+    bool m_projectPackagesLoaded = false;
     bool m_isInstalled = false;
 };
 

--- a/libdiscover/backends/PackageKitBackend/CoprTransaction.cpp
+++ b/libdiscover/backends/PackageKitBackend/CoprTransaction.cpp
@@ -102,6 +102,11 @@ void CoprTransaction::installPackage()
         return;
     }
     QString packageName = m_resource->packageName();
+    if (packageName.isEmpty()) {
+        Q_EMIT passiveMessage(i18n("No installable package is known for this COPR project yet"));
+        setStatus(DoneWithErrorStatus);
+        return;
+    }
 
     qCDebug(LIBDISCOVER_BACKEND_PACKAGEKIT_LOG) << "Installing package:" << packageName;
 
@@ -125,6 +130,11 @@ void CoprTransaction::removePackage()
         return;
     }
     QString packageName = m_resource->packageName();
+    if (packageName.isEmpty()) {
+        Q_EMIT passiveMessage(i18n("No installed package is known for this COPR resource"));
+        setStatus(DoneWithErrorStatus);
+        return;
+    }
 
     qCDebug(LIBDISCOVER_BACKEND_PACKAGEKIT_LOG) << "Removing package:" << packageName;
     setProgress(50);
@@ -135,31 +145,6 @@ void CoprTransaction::removePackage()
     args << QStringLiteral("remove");
     args << QStringLiteral("-y");
     args << packageName;
-
-    m_process->start(QStringLiteral("pkexec"), args);
-}
-
-void CoprTransaction::disableCoprRepo()
-{
-    m_state = DisableRepo;
-    setStatus(CommittingStatus);
-    setProgress(90);
-
-    if (!m_resource) {
-        setStatus(DoneWithErrorStatus);
-        return;
-    }
-    QString coprRepo = m_resource->coprOwner() + QStringLiteral("/") + m_resource->coprProject();
-
-    qCDebug(LIBDISCOVER_BACKEND_PACKAGEKIT_LOG) << "Disabling COPR repository:" << coprRepo;
-
-    // Use pkexec to run dnf copr disable with privileges
-    QStringList args;
-    args << QStringLiteral("dnf");
-    args << QStringLiteral("copr");
-    args << QStringLiteral("disable");
-    args << QStringLiteral("-y");
-    args << coprRepo;
 
     m_process->start(QStringLiteral("pkexec"), args);
 }
@@ -191,8 +176,13 @@ void CoprTransaction::processFinished(int exitCode, QProcess::ExitStatus exitSta
         break;
     case InstallPackage:
         if (m_role == RemoveRole) {
-            // After removing the package, also disable the COPR repository
-            disableCoprRepo();
+            if (m_resource) {
+                m_resource->setState(AbstractResource::None);
+                qCDebug(LIBDISCOVER_BACKEND_PACKAGEKIT_LOG) << "Package removed successfully, COPR repository left enabled";
+                Q_EMIT passiveMessage(i18n("Package %1 has been removed", m_resource->name()));
+            }
+            setProgress(100);
+            setStatus(DoneStatus);
         } else {
             // Update resource state to installed
             if (m_resource) {
@@ -203,16 +193,6 @@ void CoprTransaction::processFinished(int exitCode, QProcess::ExitStatus exitSta
             setProgress(100);
             setStatus(DoneStatus);
         }
-        break;
-    case DisableRepo:
-        // Update resource state to not installed
-        if (m_resource) {
-            m_resource->setState(AbstractResource::None);
-            qCDebug(LIBDISCOVER_BACKEND_PACKAGEKIT_LOG) << "Package and repository removed successfully";
-            Q_EMIT passiveMessage(i18n("Package %1 and its COPR repository have been removed", m_resource->name()));
-        }
-        setProgress(100);
-        setStatus(DoneStatus);
         break;
     default:
         break;

--- a/libdiscover/backends/PackageKitBackend/CoprTransaction.h
+++ b/libdiscover/backends/PackageKitBackend/CoprTransaction.h
@@ -27,7 +27,6 @@ private:
     void enableCoprRepo();
     void installPackage();
     void removePackage();
-    void disableCoprRepo();
 
     QPointer<CoprResource> m_resource;
     PackageKitBackend *m_backend;
@@ -36,7 +35,6 @@ private:
     enum State {
         EnableRepo,
         InstallPackage,
-        DisableRepo,
         Done
     };
     State m_state;

--- a/libdiscover/backends/PackageKitBackend/PackageKitBackend.cpp
+++ b/libdiscover/backends/PackageKitBackend/PackageKitBackend.cpp
@@ -96,6 +96,76 @@ PackageOrAppId makePackageId(const QString &id)
     return {id, true};
 }
 
+static QString coprProjectKey(const QString &owner, const QString &project)
+{
+    return QStringLiteral("%1/%2").arg(owner, project);
+}
+
+static QString coprPackageKey(const QString &owner, const QString &project, const QString &package)
+{
+    return QStringLiteral("%1/%2:%3").arg(owner, project, package);
+}
+
+static CoprPackageInfo packageInfoFromProject(const CoprProjectInfo &project, const QString &currentChroot)
+{
+    CoprPackageInfo packageInfo;
+    packageInfo.name = project.name;
+    packageInfo.owner = project.owner;
+    packageInfo.projectName = project.name;
+    packageInfo.projectFullName = project.fullName;
+    packageInfo.description = project.description;
+    packageInfo.availableChroots = project.chroots;
+    packageInfo.homepage = project.homepage;
+    packageInfo.instructions = project.instructions;
+    packageInfo.contact = project.contact;
+    packageInfo.additionalRepos = project.additionalRepos;
+    packageInfo.repoPriority = project.repoPriority;
+    packageInfo.appstream = project.appstream;
+    packageInfo.develMode = project.develMode;
+    packageInfo.enableNet = project.enableNet;
+    packageInfo.followFedoraBranching = project.followFedoraBranching;
+    packageInfo.autoPrune = project.autoPrune;
+    packageInfo.moduleHotfixes = project.moduleHotfixes;
+    packageInfo.isProjectResource = true;
+    packageInfo.isAvailableForCurrentFedora = packageInfo.availableChroots.contains(currentChroot);
+    return packageInfo;
+}
+
+static CoprPackageInfo enrichPackageInfo(CoprPackageInfo packageInfo, const CoprProjectInfo &project, const QString &currentChroot)
+{
+    packageInfo.projectFullName = project.fullName;
+    packageInfo.description = project.description;
+    if (packageInfo.homepage.isEmpty()) {
+        packageInfo.homepage = project.homepage;
+    }
+    packageInfo.instructions = project.instructions;
+    packageInfo.contact = project.contact;
+    packageInfo.additionalRepos = project.additionalRepos;
+    packageInfo.repoPriority = project.repoPriority;
+    packageInfo.appstream = project.appstream;
+    packageInfo.develMode = project.develMode;
+    packageInfo.enableNet = project.enableNet;
+    packageInfo.followFedoraBranching = project.followFedoraBranching;
+    packageInfo.autoPrune = project.autoPrune;
+    packageInfo.moduleHotfixes = project.moduleHotfixes;
+    if (packageInfo.availableChroots.isEmpty()) {
+        packageInfo.availableChroots = project.chroots;
+    }
+    packageInfo.isAvailableForCurrentFedora = packageInfo.availableChroots.contains(currentChroot);
+    return packageInfo;
+}
+
+static bool rpmInfoMatchesCoprOwner(const QString &packageName, const QString &owner, const QString &rpmInfo)
+{
+    const QString userVendor = QStringLiteral("Fedora Copr - user ") + owner;
+    const QString groupVendor = QStringLiteral("Fedora Copr - group ") + owner;
+    const QString sourcePattern = owner + QStringLiteral("-") + packageName;
+    const QString sourcePatternWithCopr = QStringLiteral("copr:") + owner;
+
+    return rpmInfo.contains(userVendor, Qt::CaseInsensitive) || rpmInfo.contains(groupVendor, Qt::CaseInsensitive)
+        || rpmInfo.contains(sourcePattern, Qt::CaseInsensitive) || rpmInfo.contains(sourcePatternWithCopr, Qt::CaseInsensitive);
+}
+
 PackageOrAppId makeResourceId(PackageKitResource *resource)
 {
     auto appstreamResource = qobject_cast<AppPackageKitResource *>(resource);
@@ -237,6 +307,7 @@ PackageKitBackend::PackageKitBackend(QObject *parent)
     m_coprClient = new CoprClient(this);
     connect(m_coprClient, &CoprClient::projectsFound, this, &PackageKitBackend::onCoprProjectsFound);
     connect(m_coprClient, &CoprClient::packagesFound, this, &PackageKitBackend::onCoprPackagesFound);
+    connect(m_coprClient, &CoprClient::projectPackagesFound, this, &PackageKitBackend::onCoprProjectPackagesFound);
     connect(m_coprClient, &CoprClient::errorOccurred, this, [](const QString &error) {
         qCWarning(LIBDISCOVER_BACKEND_PACKAGEKIT_LOG) << "COPR error:" << error;
     });
@@ -793,10 +864,11 @@ ResultsStream *PackageKitBackend::search(const AbstractResourcesBackend::Filters
     qCDebug(LIBDISCOVER_BACKEND_PACKAGEKIT_LOG) << "search() called with: origin=" << filter.origin << "search=" << filter.search
                                                 << "category=" << filter.category;
 
-    // Clean up existing COPR stream and cancel pending requests when switching categories
+    // Clean up existing COPR stream only when a new COPR query replaces it.
+    // Discover also issues background searches for non-COPR categories while the
+    // COPR page is visible; those must not cancel the active COPR stream.
     if (m_currentSearchStream) {
-        // If we're switching away from COPR or starting a new search
-        if (filter.origin != QStringLiteral("COPR") || (filter.origin == QStringLiteral("COPR") && m_lastCoprSearchQuery != filter.search)) {
+        if (filter.origin == QStringLiteral("COPR") && m_lastCoprSearchQuery != filter.search) {
             qCDebug(LIBDISCOVER_BACKEND_PACKAGEKIT_LOG) << "Cleaning up previous COPR stream and cancelling requests";
 
             // Cancel all pending COPR requests first
@@ -813,6 +885,10 @@ ResultsStream *PackageKitBackend::search(const AbstractResourcesBackend::Filters
             m_coprOffset = 0;
             m_coprBatchPending = 0;
             m_coprBatchBuffer.clear();
+            m_coprProjectMetadata.clear();
+            m_coprProjectRelevance.clear();
+            m_coprPackageRequests.clear();
+            m_coprSearchPagePending = false;
             // Note: m_coprResources intentionally NOT cleared here.
             // This branch fires when Discover calls search("","",nullptr) internally
             // (e.g. on detail-page open). Emitting resourceRemoved here would drop all
@@ -846,14 +922,14 @@ ResultsStream *PackageKitBackend::search(const AbstractResourcesBackend::Filters
         m_lastCoprSearchQuery.clear();
         m_coprBatchPending = 0;
         m_coprBatchBuffer.clear();
+        m_coprProjectMetadata.clear();
+        m_coprProjectRelevance.clear();
+        m_coprPackageRequests.clear();
+        m_coprSearchPagePending = false;
 
-        // Clean up old COPR resources to prevent memory accumulation
-        for (auto it = m_coprResources.cbegin(); it != m_coprResources.cend(); ++it) {
-            m_packages.packages.remove(makeAppId(it.key()));
-            Q_EMIT resourceRemoved(it.value());
-            it.value()->deleteLater();
-        }
-        m_coprResources.clear();
+        // Keep existing COPR resources alive. The QML list can still hold
+        // delegates for the previous stream while a new stream is starting.
+        // Removing resources here turns those delegates into null resources.
 
         // Load popular projects asynchronously
         loadPopularCoprProjects();
@@ -880,14 +956,14 @@ ResultsStream *PackageKitBackend::search(const AbstractResourcesBackend::Filters
         m_coprOffset = 0;
         m_coprBatchPending = 0;
         m_coprBatchBuffer.clear();
+        m_coprProjectMetadata.clear();
+        m_coprProjectRelevance.clear();
+        m_coprPackageRequests.clear();
+        m_coprSearchPagePending = false;
 
-        // Clean up old COPR resources to prevent memory accumulation
-        for (auto it = m_coprResources.cbegin(); it != m_coprResources.cend(); ++it) {
-            m_packages.packages.remove(makeAppId(it.key()));
-            Q_EMIT resourceRemoved(it.value());
-            it.value()->deleteLater();
-        }
-        m_coprResources.clear();
+        // Keep existing COPR resources alive while search results are replaced.
+        // The proxy model owns the visible result set; synchronous resource
+        // removal here causes transient null delegates in QML.
 
         // Create and return a stream for COPR search results
         auto stream = PKResultsStream::create(this, QStringLiteral("COPR-search"));
@@ -1050,20 +1126,14 @@ ResultsStream *PackageKitBackend::search(const AbstractResourcesBackend::Filters
                     });
                 }
 
-                // Search via PackageKit when:
-                // 1. There's a search query, OR
-                // 2. Browsing a top-level category (to show all packages from all repos)
-                bool isTopLevelCategory = filter.category && !filter.category->parentCategory();
-                bool shouldSearchPackageKit = !filter.search.isEmpty() || isTopLevelCategory;
+                // PackageKit name search has no category constraint. When browsing a
+                // category, AppStream already provides category-filtered results; adding
+                // PackageKit's unfiltered package list makes category pages drift into
+                // unrelated applications.
+                const bool shouldSearchPackageKit = !filter.search.isEmpty() && !filter.category;
 
                 if (shouldSearchPackageKit) {
-                    PackageKit::Transaction *pkTransaction;
-                    if (!filter.search.isEmpty()) {
-                        pkTransaction = PackageKit::Daemon::searchNames(filter.search, PackageKit::Transaction::FilterNotSource);
-                    } else {
-                        // For top-level categories without search, get all GUI applications only
-                        pkTransaction = PackageKit::Daemon::getPackages(PackageKit::Transaction::FilterApplication | PackageKit::Transaction::FilterNotSource);
-                    }
+                    PackageKit::Transaction *pkTransaction = PackageKit::Daemon::searchNames(filter.search, PackageKit::Transaction::FilterNotSource);
                     QPointer<PKResultsStream> streamPtr(stream);
 
                     // Collect found packages in a local set to avoid relying on m_packagesToAdd
@@ -1343,7 +1413,7 @@ Transaction *PackageKitBackend::removeApplication(AbstractResource *app)
     // Check if this is a COPR resource
     auto coprResource = qobject_cast<CoprResource *>(app);
     if (coprResource) {
-        // Use special COPR transaction that handles dnf copr disable
+        // Use special COPR transaction that removes the package but leaves the repository enabled.
         return new CoprTransaction(coprResource, Transaction::RemoveRole, this);
     }
 
@@ -1645,6 +1715,80 @@ void PackageKitBackend::aboutTo(AboutToAction action)
     m_updater->setOfflineUpdateAction(packageKitAction);
 }
 
+void PackageKitBackend::requestCoprInstalledStateCheck(CoprResource *resource)
+{
+    if (!resource) {
+        return;
+    }
+
+    const QString packageName = resource->packageName();
+    if (packageName.isEmpty()) {
+        resource->setInstalledStateFromSystem(false);
+        return;
+    }
+
+    if (m_coprInstalledStatePendingResources.contains(resource)) {
+        return;
+    }
+
+    m_coprInstalledStatePendingResources.insert(resource);
+    connect(resource, &QObject::destroyed, this, [this, resource] {
+        m_coprInstalledStatePendingResources.remove(resource);
+    });
+
+    CoprInstalledStateRequest request;
+    request.resource = resource;
+    request.resourceKey = resource;
+    request.packageName = packageName;
+    request.owner = resource->coprOwner();
+    m_coprInstalledStateQueue.enqueue(request);
+
+    qCDebug(LIBDISCOVER_BACKEND_PACKAGEKIT_LOG) << "Queued COPR installed-state check for" << resource->coprOwner() << "/" << resource->coprProject()
+                                                << "package:" << packageName << "queue size:" << m_coprInstalledStateQueue.size();
+    processNextCoprInstalledStateCheck();
+}
+
+void PackageKitBackend::processNextCoprInstalledStateCheck()
+{
+    while (m_activeCoprInstalledStateChecks < MaxConcurrentCoprInstalledStateChecks && !m_coprInstalledStateQueue.isEmpty()) {
+        const CoprInstalledStateRequest request = m_coprInstalledStateQueue.dequeue();
+        if (!request.resource) {
+            m_coprInstalledStatePendingResources.remove(request.resourceKey);
+            continue;
+        }
+
+        auto *process = new QProcess(this);
+        ++m_activeCoprInstalledStateChecks;
+
+        qCDebug(LIBDISCOVER_BACKEND_PACKAGEKIT_LOG) << "Checking COPR installed state via rpm for" << request.owner << request.packageName
+                                                    << "active:" << m_activeCoprInstalledStateChecks << "queued:" << m_coprInstalledStateQueue.size();
+
+        connect(process,
+                QOverload<int, QProcess::ExitStatus>::of(&QProcess::finished),
+                this,
+                [this, process, request](int exitCode, QProcess::ExitStatus exitStatus) {
+                    const QString output = QString::fromUtf8(process->readAllStandardOutput());
+                    const bool installedFromCopr =
+                        exitStatus == QProcess::NormalExit && exitCode == 0 && rpmInfoMatchesCoprOwner(request.packageName, request.owner, output);
+
+                    if (request.resource) {
+                        request.resource->setInstalledStateFromSystem(installedFromCopr);
+                    }
+
+                    m_coprInstalledStatePendingResources.remove(request.resourceKey);
+                    --m_activeCoprInstalledStateChecks;
+                    process->deleteLater();
+                    processNextCoprInstalledStateCheck();
+                });
+
+        connect(process, &QProcess::errorOccurred, this, [process](QProcess::ProcessError error) {
+            qCWarning(LIBDISCOVER_BACKEND_PACKAGEKIT_LOG) << "COPR installed-state rpm process error:" << error << process->program() << process->arguments();
+        });
+
+        process->start(QStringLiteral("rpm"), {QStringLiteral("-qi"), request.packageName});
+    }
+}
+
 void PackageKitBackend::searchCoprPackages(const QString &query)
 {
     if (!m_coprClient) {
@@ -1655,14 +1799,12 @@ void PackageKitBackend::searchCoprPackages(const QString &query)
     qCDebug(LIBDISCOVER_BACKEND_PACKAGEKIT_LOG) << "Searching COPR packages for query:" << query;
     m_lastCoprSearchQuery = query;
 
-    // Batch load: 3 pages in parallel for better initial relevance sorting
     m_coprBatchBuffer.clear();
-    m_coprBatchPending = 3;
-    m_coprOffset = 60; // 3 pages of 20 already requested
+    m_coprBatchPending = 0;
+    m_coprOffset = 20;
+    m_coprSearchPagePending = true;
 
     m_coprClient->searchProjects(query, 20, 0);
-    m_coprClient->searchProjects(query, 20, 20);
-    m_coprClient->searchProjects(query, 20, 40);
 }
 
 void PackageKitBackend::loadPopularCoprProjects()
@@ -1703,7 +1845,12 @@ void PackageKitBackend::loadMoreCoprProjects()
     // Check if we're in search mode or browse mode
     if (!m_lastCoprSearchQuery.isEmpty()) {
         // Search mode: single page append (initial batch already loaded 3 pages)
+        if (m_coprSearchPagePending) {
+            qCDebug(LIBDISCOVER_BACKEND_PACKAGEKIT_LOG) << "COPR search page already pending, skipping fetchMore";
+            return;
+        }
         qCDebug(LIBDISCOVER_BACKEND_PACKAGEKIT_LOG) << "Loading more search results for query:" << m_lastCoprSearchQuery << "offset:" << m_coprOffset;
+        m_coprSearchPagePending = true;
         m_coprClient->searchProjects(m_lastCoprSearchQuery, 20, m_coprOffset);
         m_coprOffset += 20;
     } else {
@@ -1715,6 +1862,9 @@ void PackageKitBackend::loadMoreCoprProjects()
 void PackageKitBackend::onCoprProjectsFound(const QList<CoprProjectInfo> &projects)
 {
     qCDebug(LIBDISCOVER_BACKEND_PACKAGEKIT_LOG) << "Found" << projects.size() << "COPR projects";
+    if (!m_lastCoprSearchQuery.isEmpty()) {
+        m_coprSearchPagePending = false;
+    }
 
     // Batch loading: accumulate results from parallel initial requests
     if (m_coprBatchPending > 0) {
@@ -1739,7 +1889,7 @@ void PackageKitBackend::onCoprProjectsFound(const QList<CoprProjectInfo> &projec
     results.reserve(projectsToProcess.size());
 
     for (const CoprProjectInfo &project : projectsToProcess) {
-        QString key = QStringLiteral("%1/%2").arg(project.owner, project.name);
+        const QString key = coprProjectKey(project.owner, project.name);
 
         // Calculate relevance score FIRST - filter out irrelevant results when searching
         int relevanceScore = 50; // Base score for browse mode
@@ -1775,23 +1925,40 @@ void PackageKitBackend::onCoprProjectsFound(const QList<CoprProjectInfo> &projec
             }
         }
 
+        if (!searchQuery.isEmpty()) {
+            CoprResource *resource = nullptr;
+            if (m_coprResources.contains(key)) {
+                resource = m_coprResources[key];
+            } else {
+                const QString currentChroot = m_coprClient ? m_coprClient->getCurrentChroot() : QString();
+                CoprPackageInfo packageInfo = packageInfoFromProject(project, currentChroot);
+
+                resource = new CoprResource(packageInfo, this);
+                m_coprResources[key] = resource;
+
+                const auto packageId = makeAppId(key);
+                m_packages.packages[packageId] = resource;
+            }
+
+            results.append(StreamResult(resource, relevanceScore));
+            m_coprProjectMetadata[key] = project;
+            m_coprProjectRelevance[key] = relevanceScore;
+            if (!m_coprPackageRequests.contains(key) && m_coprClient) {
+                m_coprPackageRequests.insert(key);
+                m_coprClient->getProjectPackages(project.owner, project.name);
+                qCDebug(LIBDISCOVER_BACKEND_PACKAGEKIT_LOG) << "Queued COPR package lookup for search result:" << key << "score:" << relevanceScore;
+            }
+            qCDebug(LIBDISCOVER_BACKEND_PACKAGEKIT_LOG) << "COPR project search result:" << project.owner << "/" << project.name << "score:" << relevanceScore;
+            continue;
+        }
+
         // Create or reuse resource
         CoprResource *resource = nullptr;
         if (m_coprResources.contains(key)) {
             resource = m_coprResources[key];
         } else {
-            // Create a package info from project info
-            CoprPackageInfo packageInfo;
-            packageInfo.name = project.name;
-            packageInfo.owner = project.owner;
-            packageInfo.projectName = project.name;
-            packageInfo.description = project.description;
-            packageInfo.availableChroots = project.chroots;
-            packageInfo.homepage = project.homepage;
-
-            // Check if available for current Fedora
-            QString currentChroot = m_coprClient ? m_coprClient->getCurrentChroot() : QString();
-            packageInfo.isAvailableForCurrentFedora = packageInfo.availableChroots.contains(currentChroot);
+            const QString currentChroot = m_coprClient ? m_coprClient->getCurrentChroot() : QString();
+            CoprPackageInfo packageInfo = packageInfoFromProject(project, currentChroot);
 
             resource = new CoprResource(packageInfo, this);
             m_coprResources[key] = resource;
@@ -1862,6 +2029,87 @@ void PackageKitBackend::onCoprPackagesFound(const QList<CoprPackageInfo> &packag
         qCDebug(LIBDISCOVER_BACKEND_PACKAGEKIT_LOG) << "Have" << results.size() << "COPR results but stream was cancelled or deleted";
     } else if (results.isEmpty()) {
         qCDebug(LIBDISCOVER_BACKEND_PACKAGEKIT_LOG) << "No COPR results to send";
+    }
+}
+
+void PackageKitBackend::onCoprProjectPackagesFound(const QString &owner, const QString &project, const QList<CoprPackageInfo> &packages)
+{
+    qCDebug(LIBDISCOVER_BACKEND_PACKAGEKIT_LOG) << "Found" << packages.size() << "packages for COPR project" << owner << "/" << project;
+
+    const QString key = coprProjectKey(owner, project);
+    auto *projectResource = m_coprResources.value(key, nullptr);
+    if (projectResource) {
+        projectResource->setProjectPackages(packages);
+        Q_EMIT resourcesChanged(projectResource, {"longDescription", "availableVersion", "sizeDescription", "state"});
+    } else {
+        qCDebug(LIBDISCOVER_BACKEND_PACKAGEKIT_LOG) << "No COPR project resource to update for" << key;
+    }
+
+    if (m_lastCoprSearchQuery.isEmpty() || !m_coprPackageRequests.contains(key)) {
+        return;
+    }
+
+    m_coprPackageRequests.remove(key);
+
+    const QString currentChroot = m_coprClient ? m_coprClient->getCurrentChroot() : QString();
+    const CoprProjectInfo projectInfo = m_coprProjectMetadata.value(key);
+    const int projectRelevance = m_coprProjectRelevance.value(key, 50);
+    const QString lowerQuery = m_lastCoprSearchQuery.toLower();
+
+    QVector<StreamResult> results;
+    results.reserve(packages.isEmpty() ? 1 : packages.size());
+
+    for (const CoprPackageInfo &rawPackageInfo : packages) {
+        CoprPackageInfo packageInfo = m_coprProjectMetadata.contains(key) ? enrichPackageInfo(rawPackageInfo, projectInfo, currentChroot) : rawPackageInfo;
+        const QString packageKey = coprPackageKey(packageInfo.owner, packageInfo.projectName, packageInfo.name);
+
+        CoprResource *resource = nullptr;
+        if (m_coprResources.contains(packageKey)) {
+            resource = m_coprResources[packageKey];
+        } else {
+            resource = new CoprResource(packageInfo, this);
+            m_coprResources[packageKey] = resource;
+
+            const auto packageId = makeAppId(packageKey);
+            m_packages.packages[packageId] = resource;
+
+            qCDebug(LIBDISCOVER_BACKEND_PACKAGEKIT_LOG)
+                << "Created COPR package search resource:" << packageInfo.name << "from" << packageInfo.owner << "/" << packageInfo.projectName;
+        }
+
+        int relevance = projectRelevance;
+        const QString lowerPackageName = packageInfo.name.toLower();
+        if (lowerPackageName == lowerQuery) {
+            relevance = 120;
+        } else if (lowerPackageName.startsWith(lowerQuery)) {
+            relevance = 115;
+        } else if (lowerPackageName.contains(lowerQuery)) {
+            relevance = 110;
+        }
+
+        results.append(StreamResult(resource, relevance));
+    }
+
+    if (results.isEmpty() && m_coprProjectMetadata.contains(key)) {
+        CoprResource *resource = nullptr;
+        if (m_coprResources.contains(key)) {
+            resource = m_coprResources[key];
+        } else {
+            CoprPackageInfo packageInfo = packageInfoFromProject(projectInfo, currentChroot);
+            resource = new CoprResource(packageInfo, this);
+            m_coprResources[key] = resource;
+
+            const auto packageId = makeAppId(key);
+            m_packages.packages[packageId] = resource;
+        }
+        results.append(StreamResult(resource, projectRelevance));
+    }
+
+    if (!results.isEmpty() && m_currentSearchStream && !m_currentSearchStream.isNull()) {
+        std::sort(results.begin(), results.end(), [](const StreamResult &a, const StreamResult &b) {
+            return a.sortScore > b.sortScore;
+        });
+        Q_EMIT m_currentSearchStream->resourcesFound(results);
     }
 }
 

--- a/libdiscover/backends/PackageKitBackend/PackageKitBackend.h
+++ b/libdiscover/backends/PackageKitBackend/PackageKitBackend.h
@@ -11,6 +11,7 @@
 #include <PackageKit/Offline>
 #include <PackageKit/Transaction>
 #include <QPointer>
+#include <QQueue>
 #include <QSet>
 #include <QSharedPointer>
 #include <QStringList>
@@ -152,6 +153,7 @@ public:
     void searchCoprPackages(const QString &query);
     void loadPopularCoprProjects();
     void loadMoreCoprProjects();
+    void requestCoprInstalledStateCheck(CoprResource *resource);
 
 public Q_SLOTS:
     void reloadPackageList();
@@ -167,6 +169,7 @@ private Q_SLOTS:
     void loadAllPackagesHybrid();
     void onCoprProjectsFound(const QList<CoprProjectInfo> &projects);
     void onCoprPackagesFound(const QList<CoprPackageInfo> &packages);
+    void onCoprProjectPackagesFound(const QString &owner, const QString &project, const QList<CoprPackageInfo> &packages);
 
 Q_SIGNALS:
     void loadedAppStream();
@@ -194,6 +197,7 @@ private:
     void updateProxy();
     void foundNewMajorVersion(const AppStream::Release &release);
     void setRefresher(PackageKit::Transaction *refresh);
+    void processNextCoprInstalledStateCheck();
 
     QScopedPointer<AppStream::ConcurrentPool> m_appdata;
     bool m_appdataLoaded = false;
@@ -223,6 +227,20 @@ private:
     QPointer<PKResultsStream> m_currentSearchStream;
     int m_coprOffset = 0;
     QString m_lastCoprSearchQuery;
+    QHash<QString, CoprProjectInfo> m_coprProjectMetadata;
+    QHash<QString, int> m_coprProjectRelevance;
+    QSet<QString> m_coprPackageRequests;
+    bool m_coprSearchPagePending = false;
+    struct CoprInstalledStateRequest {
+        QPointer<CoprResource> resource;
+        CoprResource *resourceKey = nullptr;
+        QString packageName;
+        QString owner;
+    };
+    QQueue<CoprInstalledStateRequest> m_coprInstalledStateQueue;
+    QSet<CoprResource *> m_coprInstalledStatePendingResources;
+    int m_activeCoprInstalledStateChecks = 0;
+    static constexpr int MaxConcurrentCoprInstalledStateChecks = 2;
 
     // Batch loading: accumulate results from parallel initial requests
     QList<CoprProjectInfo> m_coprBatchBuffer;


### PR DESCRIPTION
Summary
- Enrich COPR project and package metadata shown in Discover.
- Use official COPR project search with lazy package detail loading.
- Make COPR installs package-aware and keep repositories enabled after package removal.
- Move COPR installed-state checks into a bounded async backend queue.
- Prevent PackageKit fallback results from replacing category-filtered AppStream pages.

Validation
- Built with cmake --build build --parallel $(nproc).
- Installed with sudo cmake --install build.
- Verified COPR search finds zen-browser.
- Verified category browsing no longer switches Arcade results to unrelated global applications.