### PR TITLE
Improve COPR package selection and transactions

### DIFF
--- a/libdiscover/backends/PackageKitBackend/CoprResource.cpp
+++ b/libdiscover/backends/PackageKitBackend/CoprResource.cpp
@@ -406,6 +406,10 @@ void CoprResource::setInstalledStateFromSystem(bool installed)
     const bool wasInstalled = m_isInstalled;
     m_isInstalled = installed;
 
+    if (auto pkBackend = qobject_cast<PackageKitBackend *>(backend())) {
+        pkBackend->setCoprInstalledStateCache(m_owner, m_installPackageName, installed);
+    }
+
     // Also emit the change through the backend so the UI updates
     if (wasInstalled != m_isInstalled) {
         Q_EMIT stateChanged();

--- a/libdiscover/backends/PackageKitBackend/CoprResource.cpp
+++ b/libdiscover/backends/PackageKitBackend/CoprResource.cpp
@@ -9,6 +9,7 @@
 #include <QDirIterator>
 #include <QFileInfo>
 #include <QLocale>
+#include <QVariantMap>
 
 #include <algorithm>
 
@@ -356,12 +357,39 @@ QUrl CoprResource::homepage()
     return QUrl(QStringLiteral("https://copr.fedorainfracloud.org/coprs/%1/%2/").arg(m_owner, m_project));
 }
 
+QStringList CoprResource::topObjects() const
+{
+    QStringList objects = PackageKitResource::topObjects();
+    if (m_isProjectResource) {
+        objects.append(QStringLiteral("qrc:/qml/CoprPackageSelector.qml"));
+    }
+    return objects;
+}
+
+QVariantList CoprResource::coprProjectPackages() const
+{
+    QVariantList packages;
+    packages.reserve(m_projectPackages.size());
+
+    for (const CoprPackageInfo &package : m_projectPackages) {
+        QVariantMap item;
+        item.insert(QStringLiteral("name"), package.name);
+        item.insert(QStringLiteral("version"), package.version);
+        item.insert(QStringLiteral("latestBuildState"), package.latestBuildState);
+        item.insert(QStringLiteral("availableChroots"), package.availableChroots);
+        item.insert(QStringLiteral("isAvailableForCurrentFedora"), package.isAvailableForCurrentFedora);
+        packages.append(item);
+    }
+
+    return packages;
+}
+
 AbstractResource::State CoprResource::state()
 {
     if (m_isInstalled) {
         return AbstractResource::Installed;
     }
-    if (m_installPackageName.isEmpty() && m_isProjectResource && !m_projectPackagesLoaded) {
+    if (m_installPackageName.isEmpty() && m_isProjectResource) {
         return AbstractResource::Broken;
     }
 
@@ -404,22 +432,55 @@ void CoprResource::setProjectPackages(const QList<CoprPackageInfo> &packages)
         }
     }
 
-    m_availableChroots = mergedChroots(m_availableChroots, m_projectPackages);
-    m_isAvailableForCurrentFedora = std::any_of(m_availableChroots.cbegin(), m_availableChroots.cend(), [this](const QString &chroot) {
-        if (auto pkBackend = qobject_cast<PackageKitBackend *>(backend())) {
-            if (auto client = pkBackend->coprClient()) {
-                return chroot == client->getCurrentChroot();
+    if (m_installPackageName.isEmpty()) {
+        m_availableChroots = mergedChroots(m_availableChroots, m_projectPackages);
+        m_isAvailableForCurrentFedora = std::any_of(m_availableChroots.cbegin(), m_availableChroots.cend(), [this](const QString &chroot) {
+            if (auto pkBackend = qobject_cast<PackageKitBackend *>(backend())) {
+                if (auto client = pkBackend->coprClient()) {
+                    return chroot == client->getCurrentChroot();
+                }
             }
-        }
-        return false;
-    });
+            return false;
+        });
+    }
 
     Q_EMIT longDescriptionChanged();
     Q_EMIT versionsChanged();
+    Q_EMIT projectPackagesChanged();
     if (previousState != state() || previousInstallPackageName != m_installPackageName) {
         Q_EMIT stateChanged();
     }
     if (previousInstallPackageName != m_installPackageName && !m_installPackageName.isEmpty()) {
+        QMetaObject::invokeMethod(this, &CoprResource::checkInstalledState, Qt::QueuedConnection);
+    }
+}
+
+void CoprResource::selectCoprProjectPackage(const QString &packageName)
+{
+    if (!m_isProjectResource || packageName.isEmpty()) {
+        return;
+    }
+
+    const auto it = std::find_if(m_projectPackages.cbegin(), m_projectPackages.cend(), [&packageName](const CoprPackageInfo &package) {
+        return package.name == packageName;
+    });
+    if (it == m_projectPackages.cend()) {
+        return;
+    }
+
+    const AbstractResource::State previousState = state();
+    const QString previousInstallPackageName = m_installPackageName;
+
+    m_installPackageName = it->name;
+    applyPackageDetails(*it);
+
+    Q_EMIT longDescriptionChanged();
+    Q_EMIT versionsChanged();
+    Q_EMIT projectPackagesChanged();
+    if (previousState != state() || previousInstallPackageName != m_installPackageName) {
+        Q_EMIT stateChanged();
+    }
+    if (previousInstallPackageName != m_installPackageName) {
         QMetaObject::invokeMethod(this, &CoprResource::checkInstalledState, Qt::QueuedConnection);
     }
 }
@@ -441,39 +502,22 @@ const CoprPackageInfo *CoprResource::preferredProjectPackage() const
 
 void CoprResource::applyPackageDetails(const CoprPackageInfo &package)
 {
-    if (m_version.isEmpty()) {
-        m_version = package.version;
+    m_version = package.version;
+    m_latestBuildState = package.latestBuildState;
+    m_latestBuildRepoUrl = package.latestBuildRepoUrl;
+    m_latestBuildSubmitter = package.latestBuildSubmitter;
+    m_latestBuildSubmittedOn = package.latestBuildSubmittedOn;
+    m_latestBuildStartedOn = package.latestBuildStartedOn;
+    m_latestBuildEndedOn = package.latestBuildEndedOn;
+    m_sourceType = package.sourceType;
+    m_sourceUrl = package.sourceUrl;
+    m_sourceSpec = package.sourceSpec;
+    m_sourceSubdirectory = package.sourceSubdirectory;
+
+    if (!package.availableChroots.isEmpty()) {
+        m_availableChroots = package.availableChroots;
     }
-    if (m_latestBuildState.isEmpty()) {
-        m_latestBuildState = package.latestBuildState;
-    }
-    if (m_latestBuildRepoUrl.isEmpty()) {
-        m_latestBuildRepoUrl = package.latestBuildRepoUrl;
-    }
-    if (m_latestBuildSubmitter.isEmpty()) {
-        m_latestBuildSubmitter = package.latestBuildSubmitter;
-    }
-    if (!m_latestBuildSubmittedOn.isValid()) {
-        m_latestBuildSubmittedOn = package.latestBuildSubmittedOn;
-    }
-    if (!m_latestBuildStartedOn.isValid()) {
-        m_latestBuildStartedOn = package.latestBuildStartedOn;
-    }
-    if (!m_latestBuildEndedOn.isValid()) {
-        m_latestBuildEndedOn = package.latestBuildEndedOn;
-    }
-    if (m_sourceType.isEmpty()) {
-        m_sourceType = package.sourceType;
-    }
-    if (m_sourceUrl.isEmpty()) {
-        m_sourceUrl = package.sourceUrl;
-    }
-    if (m_sourceSpec.isEmpty()) {
-        m_sourceSpec = package.sourceSpec;
-    }
-    if (m_sourceSubdirectory.isEmpty()) {
-        m_sourceSubdirectory = package.sourceSubdirectory;
-    }
+    m_isAvailableForCurrentFedora = package.isAvailableForCurrentFedora;
 }
 
 QVariant CoprResource::icon() const

--- a/libdiscover/backends/PackageKitBackend/CoprResource.h
+++ b/libdiscover/backends/PackageKitBackend/CoprResource.h
@@ -4,11 +4,17 @@
 #include "PackageKitResource.h"
 #include "CoprClient.h"
 
+#include <QVariantList>
+
 class PackageKitBackend;
 
 class CoprResource : public PackageKitResource
 {
     Q_OBJECT
+    Q_PROPERTY(bool isCoprProjectResource READ isCoprProjectResource CONSTANT)
+    Q_PROPERTY(bool coprProjectPackagesLoaded READ coprProjectPackagesLoaded NOTIFY projectPackagesChanged)
+    Q_PROPERTY(QVariantList coprProjectPackages READ coprProjectPackages NOTIFY projectPackagesChanged)
+    Q_PROPERTY(QString selectedCoprPackageName READ selectedCoprPackageName NOTIFY projectPackagesChanged)
 
 public:
     explicit CoprResource(const CoprPackageInfo &packageInfo, AbstractResourcesBackend *parent);
@@ -26,6 +32,7 @@ public:
     QString author() const override;
     QString sourceIcon() const override;
     QDate releaseDate() const override;
+    QStringList topObjects() const override;
 
     AbstractResource::State state() override;
     QVariant icon() const override;
@@ -41,10 +48,28 @@ public:
     void setInstalledStateFromSystem(bool installed);
     void setProjectPackages(const QList<CoprPackageInfo> &packages);
     Q_INVOKABLE void fetchProjectPackages();
+    Q_INVOKABLE void selectCoprProjectPackage(const QString &packageName);
     void checkInstalledState();
 
     bool canExecute() const override;
     void invokeApplication() const override;
+
+    bool isCoprProjectResource() const
+    {
+        return m_isProjectResource;
+    }
+    bool coprProjectPackagesLoaded() const
+    {
+        return m_projectPackagesLoaded;
+    }
+    QVariantList coprProjectPackages() const;
+    QString selectedCoprPackageName() const
+    {
+        return m_installPackageName;
+    }
+
+Q_SIGNALS:
+    void projectPackagesChanged();
 
 private:
     QString findDesktopFile() const;

--- a/libdiscover/backends/PackageKitBackend/CoprTransaction.cpp
+++ b/libdiscover/backends/PackageKitBackend/CoprTransaction.cpp
@@ -214,7 +214,6 @@ void CoprTransaction::processFinished(int exitCode, QProcess::ExitStatus exitSta
             if (m_resource) {
                 m_resource->setState(AbstractResource::None);
                 qCDebug(LIBDISCOVER_BACKEND_PACKAGEKIT_LOG) << "Package removed successfully, COPR repository left enabled";
-                Q_EMIT passiveMessage(i18n("Package %1 has been removed", m_resource->name()));
             }
             setProgress(100);
             setStatus(DoneStatus);
@@ -223,7 +222,6 @@ void CoprTransaction::processFinished(int exitCode, QProcess::ExitStatus exitSta
             if (m_resource) {
                 m_resource->setState(AbstractResource::Installed);
                 qCDebug(LIBDISCOVER_BACKEND_PACKAGEKIT_LOG) << "Package installed successfully, state updated to Installed";
-                Q_EMIT passiveMessage(i18n("Package %1 has been installed", m_resource->name()));
             }
             setProgress(100);
             setStatus(DoneStatus);

--- a/libdiscover/backends/PackageKitBackend/CoprTransaction.cpp
+++ b/libdiscover/backends/PackageKitBackend/CoprTransaction.cpp
@@ -53,10 +53,31 @@ void CoprTransaction::proceed()
     setStatus(DownloadingStatus);
 
     if (m_role == InstallRole) {
+        if (!canInstallForCurrentChroot()) {
+            setStatus(DoneWithErrorStatus);
+            return;
+        }
         enableCoprRepo();
     } else if (m_role == RemoveRole) {
         removePackage();
     }
+}
+
+bool CoprTransaction::canInstallForCurrentChroot()
+{
+    if (!m_resource) {
+        return false;
+    }
+
+    if (m_resource->availableChroots().isEmpty() || m_resource->isAvailableForCurrentFedora()) {
+        return true;
+    }
+
+    Q_EMIT passiveMessage(i18n("This COPR package is not available for your Fedora version."));
+    qCWarning(LIBDISCOVER_BACKEND_PACKAGEKIT_LOG) << "Refusing to install unsupported COPR package:" << m_resource->coprOwner() << "/"
+                                                  << m_resource->coprProject() << "package:" << m_resource->packageName()
+                                                  << "available chroots:" << m_resource->availableChroots();
+    return false;
 }
 
 void CoprTransaction::enableCoprRepo()

--- a/libdiscover/backends/PackageKitBackend/CoprTransaction.cpp
+++ b/libdiscover/backends/PackageKitBackend/CoprTransaction.cpp
@@ -80,6 +80,25 @@ bool CoprTransaction::canInstallForCurrentChroot()
     return false;
 }
 
+QString CoprTransaction::processDiagnosticOutput() const
+{
+    const QString stderrOutput = m_stderrBuffer.trimmed();
+    if (!stderrOutput.isEmpty()) {
+        return stderrOutput;
+    }
+
+    return m_stdoutBuffer.trimmed();
+}
+
+void CoprTransaction::startPkexec(const QStringList &arguments)
+{
+    m_stdoutBuffer.clear();
+    m_stderrBuffer.clear();
+
+    qCDebug(LIBDISCOVER_BACKEND_PACKAGEKIT_LOG) << "Starting process: pkexec" << arguments;
+    m_process->start(QStringLiteral("pkexec"), arguments);
+}
+
 void CoprTransaction::enableCoprRepo()
 {
     m_state = EnableRepo;
@@ -102,14 +121,7 @@ void CoprTransaction::enableCoprRepo()
     args << QStringLiteral("-y");  // Auto-accept
     args << coprRepo;
 
-    qCDebug(LIBDISCOVER_BACKEND_PACKAGEKIT_LOG) << "Starting process: pkexec" << args;
-    m_process->start(QStringLiteral("pkexec"), args);
-
-    if (!m_process->waitForStarted(5000)) {
-        qCWarning(LIBDISCOVER_BACKEND_PACKAGEKIT_LOG) << "Failed to start process";
-        Q_EMIT passiveMessage(i18n("Failed to start installation process"));
-        setStatus(DoneWithErrorStatus);
-    }
+    startPkexec(args);
 }
 
 void CoprTransaction::installPackage()
@@ -138,7 +150,7 @@ void CoprTransaction::installPackage()
     args << QStringLiteral("-y");
     args << packageName;
 
-    m_process->start(QStringLiteral("pkexec"), args);
+    startPkexec(args);
 }
 
 void CoprTransaction::removePackage()
@@ -167,12 +179,13 @@ void CoprTransaction::removePackage()
     args << QStringLiteral("-y");
     args << packageName;
 
-    m_process->start(QStringLiteral("pkexec"), args);
+    startPkexec(args);
 }
 
 void CoprTransaction::processFinished(int exitCode, QProcess::ExitStatus exitStatus)
 {
     qCDebug(LIBDISCOVER_BACKEND_PACKAGEKIT_LOG) << "Process finished with exit code:" << exitCode << "status:" << exitStatus;
+    processOutput();
 
     if (exitStatus == QProcess::CrashExit) {
         setStatus(DoneWithErrorStatus);
@@ -180,9 +193,10 @@ void CoprTransaction::processFinished(int exitCode, QProcess::ExitStatus exitSta
     }
 
     if (exitCode != 0) {
-        QString error = QString::fromUtf8(m_process->readAllStandardError());
-        qCWarning(LIBDISCOVER_BACKEND_PACKAGEKIT_LOG) << "Process failed:" << error;
-        Q_EMIT passiveMessage(i18n("Operation failed: %1", error));
+        const QString error = processDiagnosticOutput();
+        const QString errorMessage = error.isEmpty() ? i18n("No error output was returned") : error;
+        qCWarning(LIBDISCOVER_BACKEND_PACKAGEKIT_LOG) << "Process failed:" << errorMessage;
+        Q_EMIT passiveMessage(i18n("Operation failed: %1", errorMessage));
 
         setStatus(DoneWithErrorStatus);
         return;
@@ -227,7 +241,7 @@ void CoprTransaction::processError(QProcess::ProcessError error)
     QString errorMessage;
     switch (error) {
     case QProcess::FailedToStart:
-        errorMessage = i18n("Failed to start the installation process. Make sure 'dnf' is installed.");
+        errorMessage = i18n("Failed to start the installation process. Make sure 'pkexec' and 'dnf' are installed.");
         break;
     case QProcess::Crashed:
         errorMessage = i18n("The installation process crashed unexpectedly.");
@@ -248,11 +262,13 @@ void CoprTransaction::processOutput()
 {
     QString output = QString::fromUtf8(m_process->readAllStandardOutput());
     if (!output.isEmpty()) {
+        m_stdoutBuffer += output;
         qCDebug(LIBDISCOVER_BACKEND_PACKAGEKIT_LOG) << "Process output:" << output;
     }
 
     QString error = QString::fromUtf8(m_process->readAllStandardError());
     if (!error.isEmpty()) {
+        m_stderrBuffer += error;
         qCDebug(LIBDISCOVER_BACKEND_PACKAGEKIT_LOG) << "Process stderr:" << error;
     }
 }

--- a/libdiscover/backends/PackageKitBackend/CoprTransaction.h
+++ b/libdiscover/backends/PackageKitBackend/CoprTransaction.h
@@ -3,6 +3,8 @@
 
 #include <QPointer>
 #include <QProcess>
+#include <QString>
+#include <QStringList>
 #include <Transaction/Transaction.h>
 
 class CoprResource;
@@ -25,6 +27,8 @@ private Q_SLOTS:
 
 private:
     bool canInstallForCurrentChroot();
+    QString processDiagnosticOutput() const;
+    void startPkexec(const QStringList &arguments);
     void enableCoprRepo();
     void installPackage();
     void removePackage();
@@ -33,6 +37,8 @@ private:
     PackageKitBackend *m_backend;
     QProcess *m_process;
     Transaction::Role m_role;
+    QString m_stdoutBuffer;
+    QString m_stderrBuffer;
     enum State {
         EnableRepo,
         InstallPackage,

--- a/libdiscover/backends/PackageKitBackend/CoprTransaction.h
+++ b/libdiscover/backends/PackageKitBackend/CoprTransaction.h
@@ -24,6 +24,7 @@ private Q_SLOTS:
     void processOutput();
 
 private:
+    bool canInstallForCurrentChroot();
     void enableCoprRepo();
     void installPackage();
     void removePackage();

--- a/libdiscover/backends/PackageKitBackend/PackageKitBackend.cpp
+++ b/libdiscover/backends/PackageKitBackend/PackageKitBackend.cpp
@@ -166,6 +166,11 @@ static bool rpmInfoMatchesCoprOwner(const QString &packageName, const QString &o
         || rpmInfo.contains(sourcePattern, Qt::CaseInsensitive) || rpmInfo.contains(sourcePatternWithCopr, Qt::CaseInsensitive);
 }
 
+static QString coprInstalledStateKey(const QString &owner, const QString &packageName)
+{
+    return owner + QLatin1Char('\n') + packageName;
+}
+
 PackageOrAppId makeResourceId(PackageKitResource *resource)
 {
     auto appstreamResource = qobject_cast<AppPackageKitResource *>(resource);
@@ -1727,20 +1732,30 @@ void PackageKitBackend::requestCoprInstalledStateCheck(CoprResource *resource)
         return;
     }
 
-    if (m_coprInstalledStatePendingResources.contains(resource)) {
+    const QString owner = resource->coprOwner();
+    const QString key = coprInstalledStateKey(owner, packageName);
+    const auto cachedState = m_coprInstalledStateCache.constFind(key);
+    if (cachedState != m_coprInstalledStateCache.cend()) {
+        resource->setInstalledStateFromSystem(*cachedState);
         return;
     }
 
-    m_coprInstalledStatePendingResources.insert(resource);
+    const auto pendingKey = m_coprInstalledStatePendingKeys.constFind(resource);
+    if (pendingKey != m_coprInstalledStatePendingKeys.cend() && *pendingKey == key) {
+        return;
+    }
+
+    m_coprInstalledStatePendingKeys.insert(resource, key);
     connect(resource, &QObject::destroyed, this, [this, resource] {
-        m_coprInstalledStatePendingResources.remove(resource);
+        m_coprInstalledStatePendingKeys.remove(resource);
     });
 
     CoprInstalledStateRequest request;
     request.resource = resource;
     request.resourceKey = resource;
+    request.key = key;
     request.packageName = packageName;
-    request.owner = resource->coprOwner();
+    request.owner = owner;
     m_coprInstalledStateQueue.enqueue(request);
 
     qCDebug(LIBDISCOVER_BACKEND_PACKAGEKIT_LOG) << "Queued COPR installed-state check for" << resource->coprOwner() << "/" << resource->coprProject()
@@ -1748,12 +1763,23 @@ void PackageKitBackend::requestCoprInstalledStateCheck(CoprResource *resource)
     processNextCoprInstalledStateCheck();
 }
 
+void PackageKitBackend::setCoprInstalledStateCache(const QString &owner, const QString &packageName, bool installed)
+{
+    if (owner.isEmpty() || packageName.isEmpty()) {
+        return;
+    }
+
+    m_coprInstalledStateCache.insert(coprInstalledStateKey(owner, packageName), installed);
+}
+
 void PackageKitBackend::processNextCoprInstalledStateCheck()
 {
     while (m_activeCoprInstalledStateChecks < MaxConcurrentCoprInstalledStateChecks && !m_coprInstalledStateQueue.isEmpty()) {
         const CoprInstalledStateRequest request = m_coprInstalledStateQueue.dequeue();
         if (!request.resource) {
-            m_coprInstalledStatePendingResources.remove(request.resourceKey);
+            if (m_coprInstalledStatePendingKeys.value(request.resourceKey) == request.key) {
+                m_coprInstalledStatePendingKeys.remove(request.resourceKey);
+            }
             continue;
         }
 
@@ -1771,11 +1797,16 @@ void PackageKitBackend::processNextCoprInstalledStateCheck()
                     const bool installedFromCopr =
                         exitStatus == QProcess::NormalExit && exitCode == 0 && rpmInfoMatchesCoprOwner(request.packageName, request.owner, output);
 
-                    if (request.resource) {
+                    setCoprInstalledStateCache(request.owner, request.packageName, installedFromCopr);
+
+                    const bool isCurrentRequest = request.resource && m_coprInstalledStatePendingKeys.value(request.resourceKey) == request.key;
+                    if (isCurrentRequest) {
                         request.resource->setInstalledStateFromSystem(installedFromCopr);
+                        m_coprInstalledStatePendingKeys.remove(request.resourceKey);
+                    } else {
+                        qCDebug(LIBDISCOVER_BACKEND_PACKAGEKIT_LOG) << "Ignoring stale COPR installed-state result for" << request.owner << request.packageName;
                     }
 
-                    m_coprInstalledStatePendingResources.remove(request.resourceKey);
                     --m_activeCoprInstalledStateChecks;
                     process->deleteLater();
                     processNextCoprInstalledStateCheck();

--- a/libdiscover/backends/PackageKitBackend/PackageKitBackend.h
+++ b/libdiscover/backends/PackageKitBackend/PackageKitBackend.h
@@ -10,6 +10,7 @@
 
 #include <PackageKit/Offline>
 #include <PackageKit/Transaction>
+#include <QHash>
 #include <QPointer>
 #include <QQueue>
 #include <QSet>
@@ -154,6 +155,7 @@ public:
     void loadPopularCoprProjects();
     void loadMoreCoprProjects();
     void requestCoprInstalledStateCheck(CoprResource *resource);
+    void setCoprInstalledStateCache(const QString &owner, const QString &packageName, bool installed);
 
 public Q_SLOTS:
     void reloadPackageList();
@@ -234,11 +236,13 @@ private:
     struct CoprInstalledStateRequest {
         QPointer<CoprResource> resource;
         CoprResource *resourceKey = nullptr;
+        QString key;
         QString packageName;
         QString owner;
     };
     QQueue<CoprInstalledStateRequest> m_coprInstalledStateQueue;
-    QSet<CoprResource *> m_coprInstalledStatePendingResources;
+    QHash<CoprResource *, QString> m_coprInstalledStatePendingKeys;
+    QHash<QString, bool> m_coprInstalledStateCache;
     int m_activeCoprInstalledStateChecks = 0;
     static constexpr int MaxConcurrentCoprInstalledStateChecks = 2;
 

--- a/libdiscover/backends/PackageKitBackend/pkui.qrc
+++ b/libdiscover/backends/PackageKitBackend/pkui.qrc
@@ -1,6 +1,7 @@
 <!DOCTYPE RCC>
 <RCC version="1.0">
  <qresource>
+    <file>qml/CoprPackageSelector.qml</file>
     <file>qml/DependenciesButton.qml</file>
     <file>qml/PackageKitPermissions.qml</file>
  </qresource>

--- a/libdiscover/backends/PackageKitBackend/qml/CoprPackageSelector.qml
+++ b/libdiscover/backends/PackageKitBackend/qml/CoprPackageSelector.qml
@@ -1,0 +1,111 @@
+/*
+ *   SPDX-License-Identifier: LGPL-2.0-or-later
+ */
+
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import QtQuick.Controls as QQC2
+import QtQuick.Layouts
+import org.kde.discover as Discover
+import org.kde.kirigami as Kirigami
+
+ColumnLayout {
+    id: root
+
+    required property Discover.AbstractResource resource
+
+    Discover.Activatable.active: resource.isCoprProjectResource
+        && (!resource.coprProjectPackagesLoaded || resource.coprProjectPackages.length !== 1)
+
+    spacing: Kirigami.Units.smallSpacing
+
+    Component.onCompleted: resource.fetchProjectPackages()
+    onResourceChanged: resource.fetchProjectPackages()
+
+    function packageSubtitle(packageData): string {
+        const parts = [];
+        if (packageData.latestBuildState) {
+            parts.push(i18nd("libdiscover", "latest build: %1", packageData.latestBuildState));
+        }
+        if (packageData.availableChroots.length > 0) {
+            if (packageData.isAvailableForCurrentFedora) {
+                parts.push(i18nd("libdiscover", "available for this Fedora version"));
+            } else {
+                parts.push(i18nd("libdiscover", "not built for this Fedora version"));
+            }
+        }
+        return parts.join(" - ");
+    }
+
+    Kirigami.InlineMessage {
+        Layout.fillWidth: true
+        type: root.resource.coprProjectPackagesLoaded && root.resource.coprProjectPackages.length === 0
+            ? Kirigami.MessageType.Warning
+            : Kirigami.MessageType.Information
+        text: {
+            if (!root.resource.coprProjectPackagesLoaded) {
+                return i18nd("libdiscover", "Loading packages for this COPR project...");
+            }
+            if (root.resource.coprProjectPackages.length === 0) {
+                return i18nd("libdiscover", "No installable packages were returned for this COPR project.");
+            }
+            if (root.resource.selectedCoprPackageName.length === 0) {
+                return i18nd("libdiscover", "Choose which package to install from this COPR project.");
+            }
+            return i18nd("libdiscover", "Selected package: %1", root.resource.selectedCoprPackageName);
+        }
+        visible: true
+        showCloseButton: false
+    }
+
+    ColumnLayout {
+        Layout.fillWidth: true
+        spacing: Kirigami.Units.smallSpacing
+        visible: root.resource.coprProjectPackagesLoaded && root.resource.coprProjectPackages.length > 1
+
+        Repeater {
+            model: root.resource.coprProjectPackages
+
+            delegate: QQC2.ItemDelegate {
+                id: delegate
+
+                required property var modelData
+
+                Layout.fillWidth: true
+                onClicked: root.resource.selectCoprProjectPackage(modelData.name)
+
+                contentItem: RowLayout {
+                    spacing: Kirigami.Units.smallSpacing
+
+                    QQC2.RadioButton {
+                        checked: root.resource.selectedCoprPackageName === delegate.modelData.name
+                        onClicked: root.resource.selectCoprProjectPackage(delegate.modelData.name)
+                    }
+
+                    ColumnLayout {
+                        Layout.fillWidth: true
+                        spacing: 0
+
+                        QQC2.Label {
+                            Layout.fillWidth: true
+                            text: delegate.modelData.version
+                                ? i18nd("libdiscover", "%1 (%2)", delegate.modelData.name, delegate.modelData.version)
+                                : delegate.modelData.name
+                            font.weight: Font.DemiBold
+                            wrapMode: Text.Wrap
+                        }
+
+                        QQC2.Label {
+                            Layout.fillWidth: true
+                            visible: text.length > 0
+                            text: root.packageSubtitle(delegate.modelData)
+                            color: Kirigami.Theme.disabledTextColor
+                            wrapMode: Text.Wrap
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a COPR project package selector for projects with multiple install targets
- keep COPR installed-state checks tied to the selected owner/package pair
- guard installs when a selected package is not available for the current Fedora chroot
- improve COPR transaction diagnostics and avoid showing successful install/remove messages as errors

## Verification
- cmake --build build --parallel $(nproc)
- sudo cmake --install build
- plasma-discover --mode copr --search zen-browser smoke test