### PR TITLE
Remove COPR repositories after package uninstall

### DIFF
--- a/libdiscover/backends/PackageKitBackend/CoprClient.cpp
+++ b/libdiscover/backends/PackageKitBackend/CoprClient.cpp
@@ -15,6 +15,12 @@
 #include <QUrl>
 #include <QUrlQuery>
 
+#if defined(WITH_MARKDOWN)
+extern "C" {
+#include <mkdio.h>
+}
+#endif
+
 CoprClient::CoprClient(QObject *parent)
     : QObject(parent)
     , m_baseUrl(QStringLiteral("https://copr.fedorainfracloud.org/api_3"))
@@ -292,7 +298,38 @@ void CoprClient::processNextRequest()
 
 QString CoprClient::convertMarkdownToHtml(const QString &markdown) const
 {
-    QString html = markdown;
+#if defined(WITH_MARKDOWN)
+    const QByteArray markdownBytes = markdown.toUtf8();
+    MMIOT *markdownHandle = mkd_string(markdownBytes.constData(), markdownBytes.size(), {});
+
+#ifdef MARKDOWN3
+    mkd_flag_t *flags = mkd_flags();
+    mkd_set_flag_num(flags, MKD_FENCEDCODE);
+    mkd_set_flag_num(flags, MKD_GITHUBTAGS);
+    mkd_set_flag_num(flags, MKD_AUTOLINK);
+    mkd_set_flag_num(flags, MKD_SAFELINK);
+    mkd_set_flag_num(flags, MKD_NOHTML);
+    const bool compiled = mkd_compile(markdownHandle, flags);
+#else
+    const bool compiled = mkd_compile(markdownHandle, MKD_FENCEDCODE | MKD_GITHUBTAGS | MKD_AUTOLINK | MKD_SAFELINK | MKD_NOHTML);
+#endif
+    if (compiled) {
+        char *htmlDocument = nullptr;
+        const int size = mkd_document(markdownHandle, &htmlDocument);
+        const QString html = QString::fromUtf8(htmlDocument, size);
+        mkd_cleanup(markdownHandle);
+#ifdef MARKDOWN3
+        mkd_free_flags(flags);
+#endif
+        return html;
+    }
+    mkd_cleanup(markdownHandle);
+#ifdef MARKDOWN3
+    mkd_free_flags(flags);
+#endif
+#endif
+
+    QString html = markdown.toHtmlEscaped();
 
     // Convert image badges with nested links like [![alt](image)](url) to clickable images
     html.replace(QRegularExpression(QStringLiteral("\\[!\\[([^\\]]*)\\]\\(([^\\)]+)\\)\\]\\(([^\\)]+)\\)")),

--- a/libdiscover/backends/PackageKitBackend/CoprTransaction.cpp
+++ b/libdiscover/backends/PackageKitBackend/CoprTransaction.cpp
@@ -155,7 +155,7 @@ void CoprTransaction::installPackage()
 
 void CoprTransaction::removePackage()
 {
-    m_state = InstallPackage;  // Reuse same state for removal
+    m_state = RemovePackage;
     setStatus(CommittingStatus);
 
     if (!m_resource) {
@@ -178,6 +178,38 @@ void CoprTransaction::removePackage()
     args << QStringLiteral("remove");
     args << QStringLiteral("-y");
     args << packageName;
+
+    startPkexec(args);
+}
+
+void CoprTransaction::removeCoprRepo()
+{
+    m_state = RemoveRepo;
+    setStatus(CommittingStatus);
+    setProgress(80);
+
+    if (!m_resource) {
+        setStatus(DoneWithErrorStatus);
+        return;
+    }
+
+    const QString owner = m_resource->coprOwner();
+    const QString project = m_resource->coprProject();
+    if (owner.isEmpty() || project.isEmpty()) {
+        Q_EMIT passiveMessage(i18n("No COPR repository is known for this resource"));
+        setStatus(DoneWithErrorStatus);
+        return;
+    }
+
+    const QString coprRepo = owner + QStringLiteral("/") + project;
+    qCDebug(LIBDISCOVER_BACKEND_PACKAGEKIT_LOG) << "Removing COPR repository:" << coprRepo;
+
+    QStringList args;
+    args << QStringLiteral("dnf");
+    args << QStringLiteral("copr");
+    args << QStringLiteral("remove");
+    args << QStringLiteral("-y");
+    args << coprRepo;
 
     startPkexec(args);
 }
@@ -210,22 +242,28 @@ void CoprTransaction::processFinished(int exitCode, QProcess::ExitStatus exitSta
         }
         break;
     case InstallPackage:
-        if (m_role == RemoveRole) {
-            if (m_resource) {
-                m_resource->setState(AbstractResource::None);
-                qCDebug(LIBDISCOVER_BACKEND_PACKAGEKIT_LOG) << "Package removed successfully, COPR repository left enabled";
-            }
-            setProgress(100);
-            setStatus(DoneStatus);
-        } else {
-            // Update resource state to installed
-            if (m_resource) {
-                m_resource->setState(AbstractResource::Installed);
-                qCDebug(LIBDISCOVER_BACKEND_PACKAGEKIT_LOG) << "Package installed successfully, state updated to Installed";
-            }
-            setProgress(100);
-            setStatus(DoneStatus);
+        // Update resource state to installed
+        if (m_resource) {
+            m_resource->setState(AbstractResource::Installed);
+            qCDebug(LIBDISCOVER_BACKEND_PACKAGEKIT_LOG) << "Package installed successfully, state updated to Installed";
         }
+        setProgress(100);
+        setStatus(DoneStatus);
+        break;
+    case RemovePackage:
+        if (m_resource) {
+            m_resource->setState(AbstractResource::None);
+            qCDebug(LIBDISCOVER_BACKEND_PACKAGEKIT_LOG) << "Package removed successfully, removing COPR repository";
+        }
+        removeCoprRepo();
+        break;
+    case RemoveRepo:
+        qCDebug(LIBDISCOVER_BACKEND_PACKAGEKIT_LOG) << "COPR repository removed successfully";
+        if (m_backend) {
+            m_backend->refreshSources();
+        }
+        setProgress(100);
+        setStatus(DoneStatus);
         break;
     default:
         break;

--- a/libdiscover/backends/PackageKitBackend/CoprTransaction.h
+++ b/libdiscover/backends/PackageKitBackend/CoprTransaction.h
@@ -32,6 +32,7 @@ private:
     void enableCoprRepo();
     void installPackage();
     void removePackage();
+    void removeCoprRepo();
 
     QPointer<CoprResource> m_resource;
     PackageKitBackend *m_backend;
@@ -42,6 +43,8 @@ private:
     enum State {
         EnableRepo,
         InstallPackage,
+        RemovePackage,
+        RemoveRepo,
         Done
     };
     State m_state;

--- a/libdiscover/backends/PackageKitBackend/PackageKitBackend.cpp
+++ b/libdiscover/backends/PackageKitBackend/PackageKitBackend.cpp
@@ -288,7 +288,8 @@ PackageKitBackend::PackageKitBackend(QObject *parent)
         updateProxy();
     });
 
-    SourcesModel::global()->addSourcesBackend(new PackageKitSourcesBackend(this));
+    m_sourcesBackend = new PackageKitSourcesBackend(this);
+    SourcesModel::global()->addSourcesBackend(m_sourcesBackend);
 
     reloadPackageList();
 
@@ -479,6 +480,13 @@ void PackageKitBackend::reloadPackageList()
             Qt::QueuedConnection);
     });
     m_appdata->loadAsync();
+}
+
+void PackageKitBackend::refreshSources()
+{
+    if (m_sourcesBackend) {
+        m_sourcesBackend->resetSources();
+    }
 }
 
 AppPackageKitResource *PackageKitBackend::addComponent(const AppStream::Component &component) const
@@ -1418,7 +1426,7 @@ Transaction *PackageKitBackend::removeApplication(AbstractResource *app)
     // Check if this is a COPR resource
     auto coprResource = qobject_cast<CoprResource *>(app);
     if (coprResource) {
-        // Use special COPR transaction that removes the package but leaves the repository enabled.
+        // Use special COPR transaction that removes the package and the COPR repository.
         return new CoprTransaction(coprResource, Transaction::RemoveRole, this);
     }
 

--- a/libdiscover/backends/PackageKitBackend/PackageKitBackend.h
+++ b/libdiscover/backends/PackageKitBackend/PackageKitBackend.h
@@ -25,6 +25,7 @@
 
 class AppPackageKitResource;
 class PackageKitUpdater;
+class PackageKitSourcesBackend;
 class OdrsReviewsBackend;
 class PKResultsStream;
 class PKResolveTransaction;
@@ -156,6 +157,7 @@ public:
     void loadMoreCoprProjects();
     void requestCoprInstalledStateCheck(CoprResource *resource);
     void setCoprInstalledStateCache(const QString &owner, const QString &packageName, bool installed);
+    void refreshSources();
 
 public Q_SLOTS:
     void reloadPackageList();
@@ -204,6 +206,7 @@ private:
     QScopedPointer<AppStream::ConcurrentPool> m_appdata;
     bool m_appdataLoaded = false;
     PackageKitUpdater *m_updater;
+    PackageKitSourcesBackend *m_sourcesBackend = nullptr;
     QPointer<PackageKit::Transaction> m_refresher;
     int m_isFetching;
     QSet<QString> m_updatesPackageId;

--- a/libdiscover/backends/PackageKitBackend/PackageKitSourcesBackend.h
+++ b/libdiscover/backends/PackageKitBackend/PackageKitSourcesBackend.h
@@ -31,9 +31,9 @@ public:
     QVariantList actions() const override;
 
     void transactionError(PackageKit::Transaction::Error, const QString &message);
+    void resetSources();
 
 private:
-    void resetSources();
     void addRepositoryDetails(const QString &id, const QString &description, bool enabled);
     QStandardItem *findItemForId(const QString &id) const;
 


### PR DESCRIPTION
## Summary
- Remove the enabled COPR repository after a COPR package is uninstalled.
- Refresh PackageKit sources after COPR repository removal so Settings no longer shows stale COPR entries.
- Render COPR project instructions with libmarkdown so fenced command blocks and links display correctly.

## Verification
- Built packagekit-backend with CMake.
- Installed the updated backend locally with cmake --install.