### PR TITLE
Add source-first application sorting

### DIFF
--- a/discover/qml/ApplicationsListPage.qml
+++ b/discover/qml/ApplicationsListPage.qml
@@ -48,6 +48,33 @@ DiscoverPage {
         return input.replace(regex, "");
     }
 
+    function resetAppsViewPosition() {
+        page.forceActiveFocus(Qt.OtherFocusReason)
+        appsView.currentIndex = -1
+        appsView.positionViewAtBeginning()
+        appsView.contentY = 0
+    }
+
+    function resetAppsViewPositionLater() {
+        page.resetAppsViewPosition()
+        Qt.callLater(function() {
+            page.resetAppsViewPosition()
+        })
+    }
+
+    function applySavedSortRole(role) {
+        page.resetAppsViewPosition()
+        DiscoverApp.DiscoverSettings[page.sortProperty] = role
+        appsModel.tempSortRole = -1
+        page.resetAppsViewPositionLater()
+    }
+
+    function applyTemporarySortRole(role) {
+        page.resetAppsViewPosition()
+        appsModel.tempSortRole = role
+        page.resetAppsViewPositionLater()
+    }
+
     property string name: categoryObject?.name ?? ""
 
     title: {
@@ -80,9 +107,9 @@ DiscoverPage {
 
     onSearchChanged: {
         if (search.length > 0) {
-            appsModel.tempSortRole = Discover.ResourcesProxyModel.SearchRelevanceRole
+            page.applyTemporarySortRole(Discover.ResourcesProxyModel.SearchRelevanceRole)
         } else {
-            appsModel.tempSortRole = -1
+            page.applyTemporarySortRole(-1)
         }
     }
 
@@ -108,19 +135,51 @@ DiscoverPage {
                 icon.name: "file-search-symbolic"
                 onTriggered: {
                     // Do *not* save the sort role on searches
-                    appsModel.tempSortRole = Discover.ResourcesProxyModel.SearchRelevanceRole
+                    page.applyTemporarySortRole(Discover.ResourcesProxyModel.SearchRelevanceRole)
                 }
                 checkable: true
                 checked: appsModel.sortRole === Discover.ResourcesProxyModel.SearchRelevanceRole
             }
             Kirigami.Action {
                 QQC2.ActionGroup.group: sortGroup
+                text: i18nc("@item:inmenu sort with RPM Fusion applications first", "RPM Fusion first")
+                icon.name: "folder-download-symbolic"
+                onTriggered: page.applySavedSortRole(Discover.ResourcesProxyModel.RpmFusionSourceRole)
+                checkable: true
+                checked: appsModel.sortRole === Discover.ResourcesProxyModel.RpmFusionSourceRole
+            }
+            Kirigami.Action {
+                QQC2.ActionGroup.group: sortGroup
+                text: i18nc("@item:inmenu sort with Fedora Linux applications first", "Fedora Linux first")
+                icon.name: "folder-download-symbolic"
+                onTriggered: page.applySavedSortRole(Discover.ResourcesProxyModel.FedoraLinuxSourceRole)
+                checkable: true
+                checked: appsModel.sortRole === Discover.ResourcesProxyModel.FedoraLinuxSourceRole
+            }
+            Kirigami.Action {
+                QQC2.ActionGroup.group: sortGroup
+                text: i18nc("@item:inmenu sort with Fedora Flatpaks first", "Fedora Flatpaks first")
+                icon.name: "flatpak-discover"
+                onTriggered: page.applySavedSortRole(Discover.ResourcesProxyModel.FedoraFlatpaksSourceRole)
+                checkable: true
+                checked: appsModel.sortRole === Discover.ResourcesProxyModel.FedoraFlatpaksSourceRole
+            }
+            Kirigami.Action {
+                QQC2.ActionGroup.group: sortGroup
+                text: i18nc("@item:inmenu sort with Flathub applications first", "Flathub first")
+                icon.name: "flatpak-discover"
+                onTriggered: page.applySavedSortRole(Discover.ResourcesProxyModel.FlathubSourceRole)
+                checkable: true
+                checked: appsModel.sortRole === Discover.ResourcesProxyModel.FlathubSourceRole
+            }
+            Kirigami.Action {
+                separator: true
+            }
+            Kirigami.Action {
+                QQC2.ActionGroup.group: sortGroup
                 text: i18n("Name")
                 icon.name: "sort-name"
-                onTriggered: {
-                    DiscoverApp.DiscoverSettings[page.sortProperty] = Discover.ResourcesProxyModel.NameRole
-                    appsModel.tempSortRole = -1
-                }
+                onTriggered: page.applySavedSortRole(Discover.ResourcesProxyModel.NameRole)
                 checkable: true
                 checked: appsModel.sortRole === Discover.ResourcesProxyModel.NameRole
             }
@@ -128,10 +187,7 @@ DiscoverPage {
                 QQC2.ActionGroup.group: sortGroup
                 text: i18n("Number of reviews")
                 icon.name: "view-pages-overview-symbolic"
-                onTriggered: {
-                    DiscoverApp.DiscoverSettings[page.sortProperty] = Discover.ResourcesProxyModel.RatingCountRole
-                    appsModel.tempSortRole = -1
-                }
+                onTriggered: page.applySavedSortRole(Discover.ResourcesProxyModel.RatingCountRole)
                 checkable: true
                 checked: appsModel.sortRole === Discover.ResourcesProxyModel.RatingCountRole
             }
@@ -139,10 +195,7 @@ DiscoverPage {
                 QQC2.ActionGroup.group: sortGroup
                 text: i18nc("@item:inmenu sort by highest-rated apps", "Rating")
                 icon.name: "rating"
-                onTriggered: {
-                    DiscoverApp.DiscoverSettings[page.sortProperty] = Discover.ResourcesProxyModel.SortableRatingRole
-                    appsModel.tempSortRole = -1
-                }
+                onTriggered: page.applySavedSortRole(Discover.ResourcesProxyModel.SortableRatingRole)
                 checkable: true
                 checked: appsModel.sortRole === Discover.ResourcesProxyModel.SortableRatingRole
             }
@@ -150,10 +203,7 @@ DiscoverPage {
                 QQC2.ActionGroup.group: sortGroup
                 text: i18n("Size")
                 icon.name: "download"
-                onTriggered: {
-                    DiscoverApp.DiscoverSettings[page.sortProperty] = Discover.ResourcesProxyModel.SizeRole
-                    appsModel.tempSortRole = -1
-                }
+                onTriggered: page.applySavedSortRole(Discover.ResourcesProxyModel.SizeRole)
                 checkable: true
                 checked: appsModel.sortRole === Discover.ResourcesProxyModel.SizeRole
             }
@@ -161,10 +211,7 @@ DiscoverPage {
                 QQC2.ActionGroup.group: sortGroup
                 text: i18n("Release date")
                 icon.name: "change-date-symbolic"
-                onTriggered: {
-                    DiscoverApp.DiscoverSettings[page.sortProperty] = Discover.ResourcesProxyModel.ReleaseDateRole
-                    appsModel.tempSortRole = -1
-                }
+                onTriggered: page.applySavedSortRole(Discover.ResourcesProxyModel.ReleaseDateRole)
                 checkable: true
                 checked: appsModel.sortRole === Discover.ResourcesProxyModel.ReleaseDateRole
             }

--- a/libdiscover/resources/ResourcesProxyModel.cpp
+++ b/libdiscover/resources/ResourcesProxyModel.cpp
@@ -41,7 +41,54 @@ const QHash<int, QByteArray> ResourcesProxyModel::s_roles = {{NameRole, "name"},
                                                              {LongDescriptionRole, "longDescription"},
                                                              {SourceIconRole, "sourceIcon"},
                                                              {SizeRole, "size"},
-                                                             {ReleaseDateRole, "releaseDate"}};
+                                                             {ReleaseDateRole, "releaseDate"},
+                                                             {RpmFusionSourceRole, "rpmFusionSourcePriority"},
+                                                             {FedoraLinuxSourceRole, "fedoraLinuxSourcePriority"},
+                                                             {FedoraFlatpaksSourceRole, "fedoraFlatpaksSourcePriority"},
+                                                             {FlathubSourceRole, "flathubSourcePriority"}};
+
+enum class PreferredSource {
+    RpmFusion,
+    FedoraLinux,
+    FedoraFlatpaks,
+    Flathub,
+};
+
+static bool matchesPreferredSource(AbstractResource *resource, PreferredSource source)
+{
+    const QString displayOrigin = resource->displayOrigin().toCaseFolded();
+    const QString origin = resource->origin().toCaseFolded();
+
+    switch (source) {
+    case PreferredSource::RpmFusion:
+        return displayOrigin.contains(QStringLiteral("rpm fusion")) || origin.contains(QStringLiteral("rpmfusion"))
+            || origin.contains(QStringLiteral("rpm fusion"));
+    case PreferredSource::FedoraLinux:
+        if (displayOrigin == QStringLiteral("fedora flatpaks") || origin.contains(QStringLiteral("flatpak"))) {
+            return false;
+        }
+        return displayOrigin == QStringLiteral("fedora linux") || displayOrigin == QStringLiteral("fedora") || origin == QStringLiteral("fedora")
+            || origin == QStringLiteral("updates") || origin == QStringLiteral("updates-testing") || origin.startsWith(QStringLiteral("fedora-"));
+    case PreferredSource::FedoraFlatpaks:
+        return displayOrigin == QStringLiteral("fedora flatpaks") || (origin.contains(QStringLiteral("fedora")) && origin.contains(QStringLiteral("flatpak")));
+    case PreferredSource::Flathub:
+        return displayOrigin == QStringLiteral("flathub") || origin.contains(QStringLiteral("flathub"));
+    }
+
+    Q_UNREACHABLE();
+    return false;
+}
+
+static int preferredSourcePriority(AbstractResource *resource, PreferredSource source)
+{
+    return matchesPreferredSource(resource, source) ? 1 : 0;
+}
+
+static bool isSourceSortRole(ResourcesProxyModel::Roles role)
+{
+    return role == ResourcesProxyModel::RpmFusionSourceRole || role == ResourcesProxyModel::FedoraLinuxSourceRole
+        || role == ResourcesProxyModel::FedoraFlatpaksSourceRole || role == ResourcesProxyModel::FlathubSourceRole;
+}
 
 int levenshteinDistance(QStringView source, QStringView target)
 {
@@ -586,6 +633,14 @@ QVariant ResourcesProxyModel::roleToValue(const StreamResult &result, int role) 
         const auto rating = resource->rating();
         return rating.sortableRating();
     }
+    case RpmFusionSourceRole:
+        return preferredSourcePriority(resource, PreferredSource::RpmFusion);
+    case FedoraLinuxSourceRole:
+        return preferredSourcePriority(resource, PreferredSource::FedoraLinux);
+    case FedoraFlatpaksSourceRole:
+        return preferredSourcePriority(resource, PreferredSource::FedoraFlatpaks);
+    case FlathubSourceRole:
+        return preferredSourcePriority(resource, PreferredSource::Flathub);
     case SearchRelevanceRole: {
         qreal rating = roleToValue(result, SortableRatingRole).value<qreal>();
 
@@ -711,7 +766,8 @@ void ResourcesProxyModel::refreshResource(AbstractResource *resource, const QVec
     const QModelIndex idx = index(row, 0);
     Q_ASSERT(idx.isValid());
     const auto roles = propertiesToRoles(properties);
-    if (roles.contains(m_sortRole)) {
+    const bool sourcePriorityChanged = isSourceSortRole(m_sortRole) && (roles.contains(DisplayOriginRole) || roles.contains(OriginRole));
+    if (roles.contains(m_sortRole) || sourcePriorityChanged) {
         beginRemoveRows({}, row, row);
         m_displayedResources.removeAt(row);
         endRemoveRows();
@@ -755,7 +811,8 @@ void ResourcesProxyModel::refreshBackend(AbstractResourcesBackend *backend, cons
         found = true;
     }
 
-    if (found && properties.contains(s_roles.value(m_sortRole))) {
+    const bool sourcePriorityChanged = isSourceSortRole(m_sortRole) && (roles.contains(DisplayOriginRole) || roles.contains(OriginRole));
+    if (found && (properties.contains(s_roles.value(m_sortRole)) || sourcePriorityChanged)) {
         invalidateSorting();
     }
 }

--- a/libdiscover/resources/ResourcesProxyModel.h
+++ b/libdiscover/resources/ResourcesProxyModel.h
@@ -91,6 +91,10 @@ public:
         LongDescriptionRole,
         SourceIconRole,
         ReleaseDateRole,
+        RpmFusionSourceRole,
+        FedoraLinuxSourceRole,
+        FedoraFlatpaksSourceRole,
+        FlathubSourceRole,
         // This is better that's always the last value as this one should be never saved to disk
         SearchRelevanceRole
     };


### PR DESCRIPTION
Adds dedicated sorting options that prioritize a selected source at the top of application lists.

Changes:
- Add source-first sort roles for RPM Fusion, Fedora Linux, Fedora Flatpaks, and Flathub.
- Add matching sort menu entries.
- Reset list focus and scroll position when changing sort order so the old selected item does not pull the view away from the top.

Validation:
- qmllint-qt6 discover/qml/ApplicationsListPage.qml
- cmake --build build --parallel $(nproc)
- sudo cmake --install build
- plasma-discover --version